### PR TITLE
fix: macd_cross paper friction parity with backtest

### DIFF
--- a/core/strategies/macd_cross_strategy.py
+++ b/core/strategies/macd_cross_strategy.py
@@ -40,19 +40,27 @@ class MacdCrossStrategy:
         self.logger = logger
         # {stock_code: (prev_hist, prev_prev_hist)} — 매일 pre_market 에서 갱신
         self._cache: Dict[str, Tuple[float, float]] = {}
+        # {stock_code: (prev_close, prev_trading_value)} — feasibility 체크용 (Fix C)
+        self._meta: Dict[str, Tuple[float, float]] = {}
         self._cache_date: Optional[str] = None
 
     def set_daily_history(
-        self, stock_code: str, df_daily: pd.DataFrame, today_yyyymmdd: str
+        self,
+        stock_code: str,
+        df_daily: pd.DataFrame,
+        today_yyyymmdd: str,
+        prev_trading_value: Optional[float] = None,
     ) -> None:
         """종목별 daily 시퀀스 주입 → MACD hist 계산 → prev/prev_prev 캐시.
 
         Args:
             df_daily: 오늘 이전 거래일까지의 일봉 (trade_date asc, close 컬럼).
             today_yyyymmdd: 진입 대상 거래일 (YYYYMMDD). 캐시 invalidation 키.
+            prev_trading_value: 전일 거래대금 (원). volume feasibility 체크용.
         """
         if self._cache_date != today_yyyymmdd:
             self._cache.clear()
+            self._meta.clear()
             self._cache_date = today_yyyymmdd
 
         if df_daily is None or df_daily.empty or len(df_daily) < self.slow + self.signal:
@@ -67,8 +75,21 @@ class MacdCrossStrategy:
         prev_prev_hist = float(hist.iloc[-2]) # 그 직전 거래일
         self._cache[stock_code] = (prev_hist, prev_prev_hist)
 
+        # 메타 캐시 (Fix C — feasibility check)
+        try:
+            d_sorted = df_daily.sort_values("trade_date")
+            prev_close = float(d_sorted["close"].iloc[-1])
+            tv = float(prev_trading_value) if prev_trading_value is not None else 0.0
+            self._meta[stock_code] = (prev_close, tv)
+        except Exception:
+            pass
+
     def get_cached_hist(self, stock_code: str) -> Tuple[Optional[float], Optional[float]]:
         return self._cache.get(stock_code, (None, None))
+
+    def get_daily_meta(self, stock_code: str) -> Tuple[Optional[float], Optional[float]]:
+        """(prev_close, prev_trading_value) 반환. feasibility check 용."""
+        return self._meta.get(stock_code, (None, None))
 
     def check_entry(self, stock_code: str, hhmm: int) -> bool:
         """진입 판정. 캐시된 hist + 시간대 + 골든크로스 충족 시 True."""

--- a/main.py
+++ b/main.py
@@ -47,6 +47,7 @@ class DayTradingBot:
         self.is_running = False
         self.pid_file = Path("bot.pid")
         self._last_eod_liquidation_date = None  # 장마감 일괄청산 실행 일자
+        self._last_paper_morning_exit_date = None  # macd_cross paper morning exit 실행 일자 (Fix B)
         
         # 프로세스 중복 실행 방지
         self._check_duplicate_process()
@@ -381,6 +382,22 @@ class DayTradingBot:
                 
                 current_time = now_kst()
 
+                # 🆕 macd_cross paper morning exit (D2 09:01~05) — backtest exit_signal 동등
+                # Fix B: backtest 의 exit 은 D2 첫 분봉에서 fire 하므로 paper 도 09:01~05
+                # 에서 1회 트리거. EOD 블록의 동일 호출이 안전망 (중복 방지는 dup-sell guard).
+                try:
+                    from config.strategy_settings import StrategySettings as _SS_ME
+                    _hhmm = current_time.hour * 100 + current_time.minute
+                    if (
+                        _SS_ME.PAPER_STRATEGY == 'macd_cross'
+                        and 901 <= _hhmm <= 905
+                        and self._last_paper_morning_exit_date != current_time.date()
+                    ):
+                        await self._macd_cross_paper_exit_task()
+                        self._last_paper_morning_exit_date = current_time.date()
+                except Exception as e:
+                    self.logger.error(f"❌ macd_cross morning exit 트리거 실패: {e}")
+
                 # 🚨 장마감 시간 시장가 일괄매도 체크 (한 번만 실행) - 동적 시간 적용
                 if MarketHours.is_eod_liquidation_time('KRX', current_time):
                     today_date = current_time.date()
@@ -566,8 +583,13 @@ class DayTradingBot:
         - decision_engine.macd_cross_strategy 의 캐시된 universe 만 평가
         - 시그널 hit 시 db_manager.save_virtual_buy 직접 호출 (VTM 우회)
         - 라이브 weighted_score 흐름과 완전 분리 — trading_manager 상태 불변
+        - 백테스트 마찰 적용: 슬리피지 + 매수 수수료 + 거래량/가격제한 feasibility
+          (backtests/common/execution_model.py 와 동등)
         """
         from config.strategy_settings import StrategySettings
+        from backtests.common.execution_model import (
+            BUY_COMMISSION, SLIPPAGE_ONE_WAY, ExecutionModel,
+        )
 
         if (
             StrategySettings.PAPER_STRATEGY != 'macd_cross'
@@ -600,20 +622,47 @@ class DayTradingBot:
                 price_info = self.intraday_manager.get_cached_current_price(stock_code)
                 if not price_info:
                     continue
-                buy_price = float(price_info.get('current_price', 0))
-                if buy_price <= 0:
+                current_price = float(price_info.get('current_price', 0))
+                if current_price <= 0:
                     continue
+
+                # Fix C: 가격제한 (상한가 buffer) 체크
+                prev_close, prev_trading_value = strategy.get_daily_meta(stock_code)
+                if prev_close and not ExecutionModel.is_price_limit_safe(
+                    current_price, prev_close, side="buy"
+                ):
+                    self.logger.debug(
+                        f"[macd_cross] {stock_code} 상한가 buffer 위반 → skip"
+                    )
+                    continue
+
+                # Fix A: 매수 슬리피지 + 수수료 적용 (backtest 동등)
+                #   buy_eff = current_price * (1 + SLIPPAGE) * (1 + BUY_COMMISSION)
+                #   pnl = (sell_eff - buy_eff) * qty 가 backtest proceed-cost 와 일치
+                buy_fill = current_price * (1 + SLIPPAGE_ONE_WAY)
+                buy_price_effective = buy_fill * (1 + BUY_COMMISSION)
 
                 ts = self.trading_manager.get_trading_stock(stock_code)
                 stock_name = ts.stock_name if ts else f"MC_{stock_code}"
 
                 budget = cfg_mc.VIRTUAL_CAPITAL * cfg_mc.BUY_BUDGET_RATIO
-                quantity = max(1, int(budget / buy_price))
+                quantity = max(1, int(budget / buy_price_effective))
+
+                # Fix C: 거래량 feasibility (order ≤ 2% 일거래대금)
+                order_value = buy_price_effective * quantity
+                if prev_trading_value and not ExecutionModel.is_volume_feasible(
+                    order_value, prev_trading_value
+                ):
+                    self.logger.debug(
+                        f"[macd_cross] {stock_code} 거래량 한도 위반 "
+                        f"(주문 {order_value:,.0f} > {prev_trading_value*0.02:,.0f}) → skip"
+                    )
+                    continue
 
                 buy_record_id = self.db_manager.save_virtual_buy(
                     stock_code=stock_code,
                     stock_name=stock_name,
-                    price=buy_price,
+                    price=buy_price_effective,
                     quantity=quantity,
                     strategy='macd_cross',
                     reason=f"macd_cross_signal_hhmm{hhmm}",
@@ -621,7 +670,7 @@ class DayTradingBot:
                 if buy_record_id:
                     self.logger.info(
                         f"👻 [macd_cross] 가상 매수: {stock_code} {quantity}주 "
-                        f"@{buy_price:,.0f} (id={buy_record_id})"
+                        f"@{buy_price_effective:,.0f} (mid={current_price:,.0f}, id={buy_record_id})"
                     )
                 else:
                     self.logger.warning(
@@ -1355,7 +1404,7 @@ class DayTradingBot:
                 try:
                     cur = conn.cursor()
                     cur.execute(
-                        """SELECT TO_CHAR(date, 'YYYYMMDD') AS trade_date, close
+                        """SELECT TO_CHAR(date, 'YYYYMMDD') AS trade_date, close, trading_value
                            FROM daily_prices
                            WHERE stock_code = %s AND date < %s AND close IS NOT NULL
                            ORDER BY date DESC
@@ -1366,11 +1415,15 @@ class DayTradingBot:
                     cur.close()
                     if not rows:
                         continue
-                    df = pd.DataFrame(rows, columns=["trade_date", "close"])
+                    df = pd.DataFrame(rows, columns=["trade_date", "close", "trading_value"])
                     df["close"] = df["close"].astype(float)
+                    # 가장 최근 거래일 거래대금 (DESC 정렬이라 첫 행)
+                    prev_tv = float(rows[0][2]) if rows[0][2] is not None else 0.0
                     # 오름차순 정렬 (가장 오래된 거래일이 첫 행)
                     df = df.iloc[::-1].reset_index(drop=True)
-                    strategy.set_daily_history(code, df, today_yyyymmdd)
+                    strategy.set_daily_history(
+                        code, df, today_yyyymmdd, prev_trading_value=prev_tv
+                    )
                     cached += 1
                 except Exception as e:
                     self.logger.debug(f"[macd_cross] daily prep {code}: {e}")
@@ -1630,14 +1683,22 @@ class DayTradingBot:
             self.logger.error(f"❌ 장마감 일괄청산 오류: {e}")
     
     async def _macd_cross_paper_exit_task(self):
-        """macd_cross 가상 포지션 hold_days=2 만료 청산 (15:00 직후 1회).
+        """macd_cross 가상 포지션 hold_days=2 만료 청산.
 
-        EOD 직후에 호출. 매수일로부터 거래일 기준 2일 경과한 가상 포지션을
-        현재가로 가상 청산한다. SL/TP 없음 (G1: 백테스트 100% 재현).
+        Fix B (2026-04-26): 청산 시점을 D2 장 시작 직후 (~09:01~05) 로 이동 — backtest
+        의 exit_signal 이 D2 첫 분봉에서 fire 하는 것과 동등. EOD (15:00) 후에도
+        한 번 더 호출되어 morning 트리거 실패 대비 안전망. save_virtual_sell 의
+        dup-prevention (buy_record_id × action='SELL' 중복 차단) 으로 idempotent.
+
+        Fix A 적용: 백테스트 마찰 동등 — sell_eff = current * (1 - SLIPPAGE) * (1 - SELL_COMMISSION)
+        Fix C 적용: 하한가 buffer 위반 종목은 skip
         """
         try:
             from config.strategy_settings import StrategySettings
             from datetime import datetime
+            from backtests.common.execution_model import (
+                SELL_COMMISSION, SLIPPAGE_ONE_WAY, ExecutionModel,
+            )
 
             cfg = StrategySettings.MacdCross
             df = self.db_manager.get_virtual_open_positions()
@@ -1647,6 +1708,7 @@ class DayTradingBot:
             if df_mc.empty:
                 return
 
+            strategy = self.decision_engine.macd_cross_strategy
             today = now_kst().date()
             for _, row in df_mc.iterrows():
                 buy_time = row['buy_time']
@@ -1663,19 +1725,37 @@ class DayTradingBot:
                 buy_record_id = int(row['id'])
                 quantity = int(row['quantity'])
 
-                # 종가 가져오기 (intraday_manager 캐시)
+                # 현재가 (intraday_manager 캐시 — 09:01~05 morning 트리거 시점에 활성)
                 price_info = self.intraday_manager.get_cached_current_price(stock_code)
                 if not price_info:
                     self.logger.warning(f"[macd_cross.exit] {stock_code} 가격 없음 → skip")
                     continue
-                sell_price = float(price_info.get('current_price', 0))
-                if sell_price <= 0:
+                current_price = float(price_info.get('current_price', 0))
+                if current_price <= 0:
                     continue
+
+                # Fix C: 하한가 buffer 체크 (sell side)
+                prev_close, _ = (
+                    strategy.get_daily_meta(stock_code) if strategy is not None else (None, None)
+                )
+                if prev_close and not ExecutionModel.is_price_limit_safe(
+                    current_price, prev_close, side="sell"
+                ):
+                    self.logger.debug(
+                        f"[macd_cross.exit] {stock_code} 하한가 buffer 위반 → skip (다음 사이클 재시도)"
+                    )
+                    continue
+
+                # Fix A: 매도 슬리피지 + 수수료/세금 적용 (backtest 동등)
+                #   sell_eff = current * (1 - SLIPPAGE) * (1 - SELL_COMMISSION)
+                #   pnl = (sell_eff - buy_eff) * qty 가 backtest proceed-cost 와 일치
+                sell_fill = current_price * (1 - SLIPPAGE_ONE_WAY)
+                sell_price_effective = sell_fill * (1 - SELL_COMMISSION)
 
                 ok = self.db_manager.save_virtual_sell(
                     stock_code=stock_code,
                     stock_name=stock_name,
-                    price=sell_price,
+                    price=sell_price_effective,
                     quantity=quantity,
                     strategy='macd_cross',
                     reason=f"hold_limit_days={days_held}",
@@ -1684,7 +1764,7 @@ class DayTradingBot:
                 if ok:
                     self.logger.info(
                         f"👻 [macd_cross] 가상 청산: {stock_code} {quantity}주 "
-                        f"@{sell_price:,.0f} (hold {days_held}d)"
+                        f"@{sell_price_effective:,.0f} (mid={current_price:,.0f}, hold {days_held}d)"
                     )
                 else:
                     self.logger.warning(

--- a/tests/strategies/test_macd_cross_strategy.py
+++ b/tests/strategies/test_macd_cross_strategy.py
@@ -46,3 +46,40 @@ def test_check_entry_false_when_no_cross():
     s = MacdCrossStrategy()
     s._cache["005930"] = (-0.1, -0.3)  # 음→음
     assert s.check_entry("005930", hhmm=1430) is False
+
+
+def test_set_daily_history_caches_meta_for_feasibility():
+    """set_daily_history(prev_trading_value=...) 가 meta cache 도 채운다 (Fix C)."""
+    s = MacdCrossStrategy(fast=14, slow=34, signal=12)
+    closes = [10000 + i * 10 for i in range(60)]
+    s.set_daily_history(
+        "005930", _daily_df(closes), today_yyyymmdd="20250401",
+        prev_trading_value=1_500_000_000,
+    )
+    prev_close, prev_tv = s.get_daily_meta("005930")
+    assert prev_close == pytest.approx(closes[-1])  # 정렬 후 최신 close
+    assert prev_tv == pytest.approx(1_500_000_000)
+
+
+def test_get_daily_meta_returns_none_for_uncached():
+    s = MacdCrossStrategy()
+    assert s.get_daily_meta("999999") == (None, None)
+
+
+def test_set_daily_history_clears_meta_on_date_change():
+    """today_yyyymmdd 바뀌면 _meta 도 함께 초기화된다."""
+    s = MacdCrossStrategy(fast=14, slow=34, signal=12)
+    closes = [10000 + i * 10 for i in range(60)]
+    s.set_daily_history(
+        "005930", _daily_df(closes), today_yyyymmdd="20250401",
+        prev_trading_value=2_000_000_000,
+    )
+    assert s.get_daily_meta("005930") != (None, None)
+
+    # 다음날 다른 종목 prep — 005930 의 meta 도 사라져야 함
+    s.set_daily_history(
+        "000660", _daily_df(closes), today_yyyymmdd="20250402",
+        prev_trading_value=1_000_000_000,
+    )
+    assert s.get_daily_meta("005930") == (None, None)
+    assert s.get_daily_meta("000660") != (None, None)


### PR DESCRIPTION
## Summary
PR #40 머지 후 follow-up. 시뮬-운영 환경 동등성 audit 결과 5개 systematic 마찰 누락 발견 → 3종 fix 적용. PR #40 으로 머지된 `feat/macd-cross-paper-integration` 의 후속 commit (`af8b1a1d`) 이 시점 엇갈림으로 main 에 미반영되어 별도 PR 으로 분리.

## 누락된 마찰 (audit 결과)
페이퍼 코드가 backtest 보다 **체계적으로 좋은 P&L** 을 기록하는 5개 결함:

| 항목 | 백테스트 | 페이퍼 (수정 전) | 누적 영향 (30 trades) |
|------|---------|----------------|------------------------|
| 매수 슬리피지 0.225% | 적용 | 미적용 | ~6.75% inflation |
| 매도 슬리피지 0.225% | 적용 | 미적용 | ~6.75% inflation |
| 매수 수수료 0.015% | 적용 | 미적용 | ~0.45% inflation |
| 매도 수수료+세금 0.245% | 적용 | 미적용 | ~7.35% inflation |
| 청산 시점 | D2 첫 분봉 | EOD (~6h 늦음) | 청산가 분포 differ |

→ 누적 ~20% 가짜 alpha. 4주 게이트 평가 무효.

## 적용된 Fix

### Fix A — 슬리피지·수수료·세금 인코딩
- 매수: `buy_eff = current * (1 + 0.225%) * (1 + 0.015%)`
- 매도: `sell_eff = current * (1 - 0.225%) * (1 - 0.245%)`
- DB 저장 `profit_loss = (sell_eff − buy_eff) × qty` 가 backtest `proceed − cost` 와 수학적으로 일치
- 상수 import: `from backtests.common.execution_model import BUY_COMMISSION, SELL_COMMISSION, SLIPPAGE_ONE_WAY`

### Fix B — 청산 시점 D2 09:01~05 로 이동
- `_last_paper_morning_exit_date` state guard 추가 (`__init__`)
- `_system_monitoring_task` 메인 루프 진입부에 morning trigger
- 기존 EOD trigger 는 backup (`save_virtual_sell` dup-prevention 으로 idempotent)
- backtest `exit_signal` 의 D2 첫 분봉 발화와 동등

### Fix C — feasibility 체크
- `MacdCrossStrategy._meta` dict 추가 — `(prev_close, prev_trading_value)` 캐시
- `set_daily_history(..., prev_trading_value=)` 인자 + `get_daily_meta()` 메서드
- `_load_macd_cross_daily_batch` SQL 이 `trading_value` 함께 fetch
- 매수: `is_price_limit_safe('buy')` (상한가 1% buffer) + `is_volume_feasible` (≤2% 일거래대금)
- 매도: `is_price_limit_safe('sell')` (하한가 1% buffer)

## 수용된 차이 (수정 안 함)
- **자본 compounding**: 5종목×200만=1M / 10M = 10% 활용도 → 4주 paper 에서 영향 미미
- **체결 지연 1분**: 즉시 체결. 슬리피지 0.225% 적용으로 OPEN vs current 차이 흡수

## 변경 파일
- `main.py`: `_evaluate_macd_cross_paper_window` (Fix A+C), `_macd_cross_paper_exit_task` (Fix A+C), `_system_monitoring_task` (Fix B trigger), `_last_paper_morning_exit_date` (Fix B state)
- `core/strategies/macd_cross_strategy.py`: `_meta` dict, `prev_trading_value` 인자, `get_daily_meta`
- `tests/strategies/test_macd_cross_strategy.py`: 3 신규 테스트 (meta cache 행위)

## Test plan
- [x] 215 passed (212 기존 + 3 신규)
- [x] 24 macd_cross 단위/통합 테스트 통과
- [x] backtest 마찰 상수 import 동작 확인
- [ ] 첫 paper trade 발생 시 로그에서 effective price 와 mid price 모두 출력되는지 확인
- [ ] 다음날 09:01~05 morning exit 트리거 발화 확인
- [ ] EOD 텔레그램 보고에서 KPI 값이 backtest OOS 와 동일 단위로 비교 가능한지 확인

## 관련 PR
- #40 (이미 머지됨) — macd_cross 페이퍼 통합 main 작업

🤖 Generated with [Claude Code](https://claude.com/claude-code)