### PR TITLE
feat: macd_cross_alt (16/32) paper 검증 활성화

### DIFF
--- a/config/strategy_settings.py
+++ b/config/strategy_settings.py
@@ -85,6 +85,7 @@ class StrategySettings:
         Spec: docs/superpowers/specs/2026-05-09-macd-cross-alt-paper-validation-design.md
         근거: MV-A 멀티버스 4ds-avg calmar 65→128 (+95%), plateau robust.
         """
+        CANDLE_INTERVAL = 1                    # MacdCross 와 인터페이스 parity
         FAST_PERIOD = 16
         SLOW_PERIOD = 32
         SIGNAL_PERIOD = 12

--- a/config/strategy_settings.py
+++ b/config/strategy_settings.py
@@ -26,7 +26,7 @@ class StrategySettings:
     # 다른 전략 (pullback / closing_trade / weighted_score) 은 모두 폐기됨.
     # 신규 전략 도입 시 valid_strategies 에 추가하고 dispatch 분기를 별도 작성한다.
     ACTIVE_STRATEGY = 'macd_cross'
-    PAPER_STRATEGY = None
+    PAPER_STRATEGY = 'macd_cross_alt'   # 2026-05-09: MV-A best 16/32 paper 검증 활성화
 
     # ========================================
     # macd_cross 전략 설정 (페이퍼 단계, 2026-04-26)

--- a/config/strategy_settings.py
+++ b/config/strategy_settings.py
@@ -77,6 +77,29 @@ class StrategySettings:
         VIRTUAL_ONLY = False
 
     # ========================================
+    # macd_cross_alt 페이퍼 (16/32 검증, 2026-05-09)
+    # ========================================
+    class MacdCrossAlt:
+        """16/32 paper 검증 (MV-A best).
+
+        Spec: docs/superpowers/specs/2026-05-09-macd-cross-alt-paper-validation-design.md
+        근거: MV-A 멀티버스 4ds-avg calmar 65→128 (+95%), plateau robust.
+        """
+        FAST_PERIOD = 16
+        SLOW_PERIOD = 32
+        SIGNAL_PERIOD = 12
+        ENTRY_HHMM_MIN = 1431
+        ENTRY_HHMM_MAX = 1500
+        HOLD_DAYS = 2
+        VIRTUAL_CAPITAL = 10_000_000
+        BUY_BUDGET_RATIO = 0.20
+        MAX_DAILY_POSITIONS = 5
+        UNIVERSE_TOP_N = 30
+        APPLY_LIVE_OVERLAY = False
+        ALLOWED_WEEKDAYS = [0, 1, 2, 3, 4]
+        VIRTUAL_ONLY = True
+
+    # ========================================
     # 실시간 종목 스크리너 설정
     # ========================================
     # macd_cross 는 자체 universe (preload_macd_cross_universe, top_n=30) 만 사용.
@@ -230,7 +253,7 @@ def validate_settings():
             f"사용 가능: {valid_strategies}"
         )
 
-    valid_paper_strategies = [None, 'macd_cross']
+    valid_paper_strategies = [None, 'macd_cross', 'macd_cross_alt']  # 'macd_cross_alt' 추가
     if StrategySettings.PAPER_STRATEGY not in valid_paper_strategies:
         raise ValueError(
             f"잘못된 페이퍼 전략: {StrategySettings.PAPER_STRATEGY}. "
@@ -245,6 +268,23 @@ def validate_settings():
             raise ValueError("MacdCross.MAX_DAILY_POSITIONS는 1 이상이어야 합니다")
         if not mc.ALLOWED_WEEKDAYS:
             raise ValueError("MacdCross.ALLOWED_WEEKDAYS가 비어있습니다")
+
+    if StrategySettings.PAPER_STRATEGY == 'macd_cross_alt':
+        mca = StrategySettings.MacdCrossAlt
+        if mca.ENTRY_HHMM_MIN >= mca.ENTRY_HHMM_MAX:
+            raise ValueError("MacdCrossAlt.ENTRY_HHMM_MIN은 ENTRY_HHMM_MAX보다 작아야 합니다")
+        if mca.MAX_DAILY_POSITIONS <= 0:
+            raise ValueError("MacdCrossAlt.MAX_DAILY_POSITIONS는 1 이상이어야 합니다")
+        if not mca.ALLOWED_WEEKDAYS:
+            raise ValueError("MacdCrossAlt.ALLOWED_WEEKDAYS가 비어있습니다")
+        if mca.UNIVERSE_TOP_N != StrategySettings.MacdCross.UNIVERSE_TOP_N:
+            raise ValueError(
+                f"MacdCrossAlt.UNIVERSE_TOP_N ({mca.UNIVERSE_TOP_N})은 "
+                f"MacdCross.UNIVERSE_TOP_N ({StrategySettings.MacdCross.UNIVERSE_TOP_N})와 "
+                f"같아야 합니다 (universe 공유 정책)"
+            )
+        if not mca.VIRTUAL_ONLY:
+            raise ValueError("MacdCrossAlt.VIRTUAL_ONLY는 True여야 합니다 (paper 전용)")
 
     return True
 

--- a/core/strategies/macd_cross_strategy.py
+++ b/core/strategies/macd_cross_strategy.py
@@ -31,6 +31,7 @@ class MacdCrossStrategy:
         entry_hhmm_min: int = 1430,
         entry_hhmm_max: int = 1500,
         logger=None,
+        label: str = 'macd_cross',
     ):
         self.fast = fast
         self.slow = slow
@@ -38,6 +39,7 @@ class MacdCrossStrategy:
         self.entry_hhmm_min = entry_hhmm_min
         self.entry_hhmm_max = entry_hhmm_max
         self.logger = logger
+        self.label = label
         # {stock_code: (prev_hist, prev_prev_hist)} — 매일 pre_market 에서 갱신
         self._cache: Dict[str, Tuple[float, float]] = {}
         # {stock_code: (prev_close, prev_trading_value)} — feasibility 체크용 (Fix C)

--- a/docs/macd_cross_operation.md
+++ b/docs/macd_cross_operation.md
@@ -93,3 +93,34 @@ class MacdCross:
 
 - **weighted_score / closing_trade / pullback**: 2026-04-27 폐기. 핵심 코드 삭제 완료. 차트 의존 잔존 코드 (`core/indicators/pullback*`, `price_calculator.py`, `visualization/*`) 는 1주 안정 운영 후 정리 예정.
 - **price_position**: 2026-04-21 완전 삭제됨.
+
+---
+
+## macd_cross_alt (16/32) Paper 검증 — 2026-05-09 ~
+
+**목적**: MV-A 멀티버스 결과 (4ds-avg calmar 65→128, +95%) 의 OOS 재현성 검증.
+
+**활성화 조건**:
+- `StrategySettings.PAPER_STRATEGY = 'macd_cross_alt'`
+- 라이브 14/34 (`ACTIVE_STRATEGY='macd_cross'`, `VIRTUAL_ONLY=False`) 그대로 유지
+- 양 인스턴스가 같은 universe top 30 공유 (KIS API 1회 호출, validate_settings 가 강제)
+
+**종료 조건**: 4주 또는 30 trades 도달 시 (먼저 충족).
+
+**승격 게이트** (모두 통과 시 swap PR — `MacdCross.FAST_PERIOD = 16, SLOW_PERIOD = 32` 일괄 교체):
+1. paper Calmar ≥ 30
+2. paper return ≥ 0
+3. paper MDD ≤ 5%
+4. paper 승률 ≥ 50%
+5. top1 trade P&L 점유율 ≤ 60%
+6. max consecutive losses ≤ 4
+
+**중도 안전정지**: 누적 -5% 또는 5연패 → `PAPER_STRATEGY=None` 자동 정지.
+
+**모니터링**:
+- 일일 EOD 텔레그램 보고에 `[macd_cross]` (real) / `[macd_cross_alt]` (paper) 두 섹션 출력
+- 운영 로그: `grep "macd_cross_alt" logs/trading_YYYYMMDD.log`
+
+**스펙/플랜**:
+- Spec: `docs/superpowers/specs/2026-05-09-macd-cross-alt-paper-validation-design.md`
+- Plan: `docs/superpowers/plans/2026-05-09-macd-cross-alt-paper-validation.md`

--- a/docs/superpowers/plans/2026-05-09-macd-cross-alt-paper-validation.md
+++ b/docs/superpowers/plans/2026-05-09-macd-cross-alt-paper-validation.md
@@ -1,0 +1,1061 @@
+# macd_cross_alt (16/32) 페이퍼 검증 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Spec `docs/superpowers/specs/2026-05-09-macd-cross-alt-paper-validation-design.md` 의 paper 16/32 검증을 라이브 14/34 실거래와 나란히 운영하기 위한 코드 구현.
+
+**Architecture:** 별도 파라미터 클래스 `MacdCrossAlt` 신설 + `MacdCrossStrategy` 인스턴스화 시 `label` 파라미터 추가. main.py 의 macd_cross 평가/청산 함수 본체를 instance 기반 helper 로 추출하고, paper 분기를 새로운 호출로 추가. KPI/DB 모듈은 기존 `virtual_trading_records.strategy` 컬럼 + DataFrame-driven KPI 그대로 재사용. 회귀 위험 최소화: 라이브 14/34 경로 변경 0.
+
+**Tech Stack:** Python 3.9, asyncio, psycopg2, pytest, KIS API.
+
+---
+
+## 사전 정보 — 엔지니어가 알아야 할 컨벤션
+
+### 기존 macd_cross 구조
+- 라이브 어댑터: `core/strategies/macd_cross_strategy.py` 의 `MacdCrossStrategy` (단일 인스턴스, 현재 `decision_engine.macd_cross_strategy` 에 owned)
+- 모드 결정: `main._macd_cross_mode()` 가 ACTIVE/PAPER/VIRTUAL_ONLY 조합으로 'real'/'virtual'/'off' 단일 문자열 반환
+- 진입 평가: `main._evaluate_macd_cross_window()` 14:31~15:00 에 mode 별 라우팅
+- 청산: `main._macd_cross_exit_dispatcher()` D+2 morning + EOD
+- KPI 집계: `core/strategies/macd_cross_kpi.py` 의 `MacdCrossKpi.compute(df_trades)` — DataFrame 인자 받음, DB 쿼리는 caller 에서
+
+### DB 스키마 (변경 없음)
+- `virtual_trading_records` 에 이미 `strategy TEXT` 컬럼 존재 (`save_virtual_buy/sell(strategy=...)` 인자가 직접 저장)
+- 기존 macd_cross paper 는 `strategy='macd_cross'` 로 저장. 신규는 `strategy='macd_cross_alt'`
+
+### Paper 인스턴스 owner
+- 라이브 인스턴스는 `decision_engine` 이 owns
+- 신규 paper 인스턴스는 `main.RoboTrader` 가 직접 owns (`self.paper_macd_cross_strategy`) — decision_engine 변경 회귀 회피
+
+### Validation
+- `config/strategy_settings.py:validate_settings()` 에 ACTIVE_STRATEGY 검증 + MacdCross 가드 존재. PAPER_STRATEGY 가 'macd_cross_alt' 일 때 동일 가드 + UNIVERSE_TOP_N 일치 강제 추가.
+
+---
+
+## 파일 구조 (생성/수정)
+
+```
+config/
+  strategy_settings.py                          [수정]  Task 1: MacdCrossAlt 클래스, valid list, validate
+
+core/strategies/
+  macd_cross_strategy.py                        [수정]  Task 2: label 파라미터 추가
+
+main.py                                         [수정]  Task 3-7: helper 추출 + paper 인스턴스 + 5 dispatch 분기
+
+tests/strategies/
+  test_macd_cross_alt_settings.py               [신규]  Task 1
+  test_macd_cross_strategy.py                   [수정]  Task 2: label 테스트 추가
+
+tests/integration/
+  test_macd_cross_alt_paper_flow.py             [신규]  Task 8
+
+docs/
+  macd_cross_operation.md                       [수정]  Task 9: 운영 노트
+```
+
+---
+
+## Task 1: MacdCrossAlt 설정 클래스 + validation (TDD)
+
+**Files:**
+- Modify: `config/strategy_settings.py`
+- Test: `tests/strategies/test_macd_cross_alt_settings.py` (신규)
+
+목적: `MacdCrossAlt` 클래스 추가 + valid list 확장 + validate_settings 가드.
+
+- [ ] **Step 1.1: 실패 테스트 작성**
+
+`tests/strategies/test_macd_cross_alt_settings.py`:
+```python
+"""MacdCrossAlt 설정 + validate_settings 가드 검증."""
+import pytest
+
+from config.strategy_settings import StrategySettings, validate_settings
+
+
+def test_macd_cross_alt_class_has_required_attrs():
+    """16/32 paper 파라미터 존재 + 값 정확."""
+    cfg = StrategySettings.MacdCrossAlt
+    assert cfg.FAST_PERIOD == 16
+    assert cfg.SLOW_PERIOD == 32
+    assert cfg.SIGNAL_PERIOD == 12
+    assert cfg.ENTRY_HHMM_MIN == 1431
+    assert cfg.ENTRY_HHMM_MAX == 1500
+    assert cfg.HOLD_DAYS == 2
+    assert cfg.VIRTUAL_CAPITAL == 10_000_000
+    assert cfg.BUY_BUDGET_RATIO == 0.20
+    assert cfg.MAX_DAILY_POSITIONS == 5
+    assert cfg.UNIVERSE_TOP_N == 30
+    assert cfg.VIRTUAL_ONLY is True
+
+
+def test_valid_paper_strategies_includes_macd_cross_alt():
+    """'macd_cross_alt' 가 valid list 에 있어야 validate_settings 통과."""
+    # 임시 PAPER_STRATEGY 변경 후 validate_settings 호출 (예외 없으면 OK)
+    original = StrategySettings.PAPER_STRATEGY
+    try:
+        StrategySettings.PAPER_STRATEGY = 'macd_cross_alt'
+        assert validate_settings() is True
+    finally:
+        StrategySettings.PAPER_STRATEGY = original
+
+
+def test_universe_top_n_must_match_macd_cross():
+    """MacdCrossAlt.UNIVERSE_TOP_N != MacdCross.UNIVERSE_TOP_N 시 ValueError."""
+    original_alt = StrategySettings.MacdCrossAlt.UNIVERSE_TOP_N
+    original_paper = StrategySettings.PAPER_STRATEGY
+    try:
+        StrategySettings.MacdCrossAlt.UNIVERSE_TOP_N = 50
+        StrategySettings.PAPER_STRATEGY = 'macd_cross_alt'
+        with pytest.raises(ValueError, match="UNIVERSE_TOP_N"):
+            validate_settings()
+    finally:
+        StrategySettings.MacdCrossAlt.UNIVERSE_TOP_N = original_alt
+        StrategySettings.PAPER_STRATEGY = original_paper
+
+
+def test_entry_hhmm_min_lt_max():
+    """ENTRY_HHMM_MIN >= MAX 시 validate_settings 가 ValueError."""
+    original_min = StrategySettings.MacdCrossAlt.ENTRY_HHMM_MIN
+    original_paper = StrategySettings.PAPER_STRATEGY
+    try:
+        StrategySettings.MacdCrossAlt.ENTRY_HHMM_MIN = 1500
+        StrategySettings.PAPER_STRATEGY = 'macd_cross_alt'
+        with pytest.raises(ValueError, match="ENTRY_HHMM_MIN"):
+            validate_settings()
+    finally:
+        StrategySettings.MacdCrossAlt.ENTRY_HHMM_MIN = original_min
+        StrategySettings.PAPER_STRATEGY = original_paper
+```
+
+- [ ] **Step 1.2: 실패 확인**
+
+```bash
+python -m pytest tests/strategies/test_macd_cross_alt_settings.py -v
+```
+Expected: 4 tests fail with `AttributeError: type object 'StrategySettings' has no attribute 'MacdCrossAlt'`.
+
+- [ ] **Step 1.3: MacdCrossAlt 클래스 추가**
+
+`config/strategy_settings.py` — `MacdCross` 클래스 직후 위치에 추가:
+
+```python
+    # ========================================
+    # macd_cross_alt 페이퍼 (16/32 검증, 2026-05-09)
+    # ========================================
+    class MacdCrossAlt:
+        """16/32 paper 검증 (MV-A best).
+
+        Spec: docs/superpowers/specs/2026-05-09-macd-cross-alt-paper-validation-design.md
+        근거: MV-A 멀티버스 4ds-avg calmar 65→128 (+95%), plateau robust.
+        """
+        FAST_PERIOD = 16
+        SLOW_PERIOD = 32
+        SIGNAL_PERIOD = 12
+        ENTRY_HHMM_MIN = 1431
+        ENTRY_HHMM_MAX = 1500
+        HOLD_DAYS = 2
+        VIRTUAL_CAPITAL = 10_000_000
+        BUY_BUDGET_RATIO = 0.20
+        MAX_DAILY_POSITIONS = 5
+        UNIVERSE_TOP_N = 30
+        APPLY_LIVE_OVERLAY = False
+        ALLOWED_WEEKDAYS = [0, 1, 2, 3, 4]
+        VIRTUAL_ONLY = True
+```
+
+- [ ] **Step 1.4: valid_paper_strategies 확장**
+
+`config/strategy_settings.py:validate_settings()`:
+
+```python
+    valid_paper_strategies = [None, 'macd_cross', 'macd_cross_alt']  # 'macd_cross_alt' 추가
+```
+
+- [ ] **Step 1.5: validate_settings 가드 추가**
+
+`if StrategySettings.ACTIVE_STRATEGY == 'macd_cross':` 블록 직후 추가:
+
+```python
+    if StrategySettings.PAPER_STRATEGY == 'macd_cross_alt':
+        mca = StrategySettings.MacdCrossAlt
+        if mca.ENTRY_HHMM_MIN >= mca.ENTRY_HHMM_MAX:
+            raise ValueError("MacdCrossAlt.ENTRY_HHMM_MIN은 ENTRY_HHMM_MAX보다 작아야 합니다")
+        if mca.MAX_DAILY_POSITIONS <= 0:
+            raise ValueError("MacdCrossAlt.MAX_DAILY_POSITIONS는 1 이상이어야 합니다")
+        if not mca.ALLOWED_WEEKDAYS:
+            raise ValueError("MacdCrossAlt.ALLOWED_WEEKDAYS가 비어있습니다")
+        if mca.UNIVERSE_TOP_N != StrategySettings.MacdCross.UNIVERSE_TOP_N:
+            raise ValueError(
+                f"MacdCrossAlt.UNIVERSE_TOP_N ({mca.UNIVERSE_TOP_N})은 "
+                f"MacdCross.UNIVERSE_TOP_N ({StrategySettings.MacdCross.UNIVERSE_TOP_N})와 "
+                f"같아야 합니다 (universe 공유 정책)"
+            )
+        if not mca.VIRTUAL_ONLY:
+            raise ValueError("MacdCrossAlt.VIRTUAL_ONLY는 True여야 합니다 (paper 전용)")
+```
+
+- [ ] **Step 1.6: 테스트 통과 확인**
+
+```bash
+python -m pytest tests/strategies/test_macd_cross_alt_settings.py -v
+```
+Expected: 4 passed.
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add config/strategy_settings.py tests/strategies/test_macd_cross_alt_settings.py
+git commit -m "$(cat <<'EOF'
+feat(config): MacdCrossAlt 설정 클래스 + validate_settings 가드
+
+MV-A best 16/32 paper 검증용. UNIVERSE_TOP_N 라이브와 동일 강제,
+VIRTUAL_ONLY=True 강제. 'macd_cross_alt' valid_paper_strategies 추가.
+
+Spec docs/superpowers/specs/2026-05-09-macd-cross-alt-paper-validation-design.md.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: MacdCrossStrategy label 파라미터 (TDD)
+
+**Files:**
+- Modify: `core/strategies/macd_cross_strategy.py`
+- Test: `tests/strategies/test_macd_cross_strategy.py` (수정)
+
+목적: 인스턴스 생성 시 logger / KPI 분리용 `label` 추가. 기본값 `'macd_cross'` 로 backwards-compat.
+
+- [ ] **Step 2.1: 실패 테스트 추가**
+
+`tests/strategies/test_macd_cross_strategy.py` 끝에 추가:
+
+```python
+def test_macd_cross_strategy_default_label():
+    """label 기본값 = 'macd_cross'."""
+    from core.strategies.macd_cross_strategy import MacdCrossStrategy
+    s = MacdCrossStrategy()
+    assert s.label == 'macd_cross'
+
+
+def test_macd_cross_strategy_custom_label():
+    """label 인자 주입 시 그대로 저장."""
+    from core.strategies.macd_cross_strategy import MacdCrossStrategy
+    s = MacdCrossStrategy(label='macd_cross_alt')
+    assert s.label == 'macd_cross_alt'
+
+
+def test_macd_cross_strategy_alt_params_via_kwargs():
+    """16/32 파라미터 주입 시 정상 보관."""
+    from core.strategies.macd_cross_strategy import MacdCrossStrategy
+    s = MacdCrossStrategy(fast=16, slow=32, signal=12,
+                          entry_hhmm_min=1431, label='macd_cross_alt')
+    assert s.fast == 16
+    assert s.slow == 32
+    assert s.signal == 12
+    assert s.entry_hhmm_min == 1431
+    assert s.label == 'macd_cross_alt'
+```
+
+- [ ] **Step 2.2: 실패 확인**
+
+```bash
+python -m pytest tests/strategies/test_macd_cross_strategy.py::test_macd_cross_strategy_default_label tests/strategies/test_macd_cross_strategy.py::test_macd_cross_strategy_custom_label tests/strategies/test_macd_cross_strategy.py::test_macd_cross_strategy_alt_params_via_kwargs -v
+```
+Expected: 3 fails with `AttributeError: 'MacdCrossStrategy' object has no attribute 'label'`.
+
+- [ ] **Step 2.3: label 파라미터 추가**
+
+`core/strategies/macd_cross_strategy.py:23` 의 `__init__` 수정:
+
+```python
+class MacdCrossStrategy:
+    """라이브 어댑터 (intraday_manager 와 결합)."""
+
+    def __init__(
+        self,
+        fast: int = 14,
+        slow: int = 34,
+        signal: int = 12,
+        entry_hhmm_min: int = 1430,
+        entry_hhmm_max: int = 1500,
+        logger=None,
+        label: str = 'macd_cross',
+    ):
+        self.fast = fast
+        self.slow = slow
+        self.signal = signal
+        self.entry_hhmm_min = entry_hhmm_min
+        self.entry_hhmm_max = entry_hhmm_max
+        self.logger = logger
+        self.label = label
+        # {stock_code: (prev_hist, prev_prev_hist)} — 매일 pre_market 에서 갱신
+        self._cache: Dict[str, Tuple[float, float]] = {}
+        self._meta: Dict[str, Tuple[float, float]] = {}
+        self._cache_date: Optional[str] = None
+```
+
+- [ ] **Step 2.4: 신규 테스트 통과 확인**
+
+```bash
+python -m pytest tests/strategies/test_macd_cross_strategy.py -v
+```
+Expected: 모두 passed (기존 + 신규 3개).
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add core/strategies/macd_cross_strategy.py tests/strategies/test_macd_cross_strategy.py
+git commit -m "$(cat <<'EOF'
+feat(strategies): MacdCrossStrategy label 파라미터 추가
+
+paper 인스턴스 (16/32) 와 라이브 (14/34) 분리 식별 + KPI/로깅 분기용.
+기본값 'macd_cross' 로 backwards-compat.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `_evaluate_macd_cross_window` 본체 → instance helper 추출 (regression-safe)
+
+**Files:**
+- Modify: `main.py:856-...` (function `_evaluate_macd_cross_window`)
+- Test: 기존 `tests/integration/test_macd_cross_paper_flow.py` 회귀 통과
+
+목적: 라이브 14/34 와 paper 16/32 가 동일 평가 로직을 다른 인스턴스/cfg/mode 로 호출 가능하게 분리.
+
+- [ ] **Step 3.1: 신규 helper `_evaluate_macd_cross_instance` 추가**
+
+`main.py` 의 `_evaluate_macd_cross_window` 정의 직전에 신규 helper 추가:
+
+```python
+async def _evaluate_macd_cross_instance(
+    self,
+    current_time,
+    *,
+    strategy,
+    cfg_class,
+    label: str,
+    mode: str,
+):
+    """단일 macd_cross 인스턴스 진입 평가.
+
+    Args:
+        strategy: MacdCrossStrategy 인스턴스 (cached universe 보유).
+        cfg_class: StrategySettings.MacdCross 또는 MacdCrossAlt.
+        label: 'macd_cross' / 'macd_cross_alt' — 로그/DB strategy 컬럼 값.
+        mode: 'real' / 'virtual' / 'off'.
+    """
+    from backtests.common.execution_model import (
+        BUY_COMMISSION, SLIPPAGE_ONE_WAY, ExecutionModel,
+    )
+
+    if mode == 'off' or strategy is None:
+        return
+    is_virtual = (mode == 'virtual')
+
+    if self._apply_holiday_guard(current_time, "매수"):
+        return
+
+    hhmm = current_time.hour * 100 + current_time.minute
+    if not (cfg_class.ENTRY_HHMM_MIN <= hhmm <= cfg_class.ENTRY_HHMM_MAX):
+        return
+
+    # 실거래 모드 한정: 서킷브레이커 inherit.
+    # paper 모드는 G1 (백테스트 100% 재현) 원칙으로 미적용.
+    if not is_virtual and self._macd_cross_circuit_breaker_blocks(current_time):
+        return
+
+    universe_codes = list(strategy._cache.keys()) if hasattr(strategy, '_cache') else []
+    if not universe_codes:
+        return
+
+    # 일일 진입 한도 — label 별로 분리 카운팅
+    def _today_buy_count() -> int:
+        return (self._count_open_paper_positions(label)
+                if is_virtual
+                else self._count_today_macd_cross_real_buys())
+
+    def _has_buy_today(code: str) -> bool:
+        return (self._has_macd_cross_paper_buy_today(code, label)
+                if is_virtual
+                else self._has_macd_cross_real_buy_today(code))
+
+    if _today_buy_count() >= cfg_class.MAX_DAILY_POSITIONS:
+        return
+
+    for stock_code in universe_codes:
+        try:
+            if not strategy.check_entry(stock_code, hhmm):
+                continue
+            if _has_buy_today(stock_code):
+                continue
+            if _today_buy_count() >= cfg_class.MAX_DAILY_POSITIONS:
+                break
+
+            price_info = self.intraday_manager.get_cached_current_price(stock_code)
+            if not price_info:
+                continue
+            current_price = float(price_info.get('current_price', 0))
+            if current_price <= 0:
+                continue
+
+            prev_close, prev_trading_value = strategy.get_daily_meta(stock_code)
+            if prev_close and not ExecutionModel.is_price_limit_safe(
+                current_price, prev_close, side="buy"
+            ):
+                self.logger.debug(
+                    f"[{label}] {stock_code} 상한가 buffer 위반 → skip"
+                )
+                continue
+
+            ts = self.trading_manager.get_trading_stock(stock_code)
+            stock_name = ts.stock_name if ts else f"MC_{stock_code}"
+
+            # ↓↓ 기존 _evaluate_macd_cross_window 본체의 매수 라우팅 코드 그대로 이동
+            # (is_virtual 분기 / save_virtual_buy(strategy=label) / execute_real_buy 등)
+            # 단 모든 strategy 인자 'macd_cross' 하드코딩을 label 변수로 교체.
+            ...
+
+        except Exception as e:
+            self.logger.exception(f"[{label}] {stock_code} 평가 오류: {e}")
+            continue
+```
+
+**중요**: Step 3.1 의 helper 본체 마지막 `...` 부분은 기존 `_evaluate_macd_cross_window` 의 매수 라우팅 코드 (line 911~ 의 for 루프 안쪽) 를 그대로 옮겨오되, `'macd_cross'` 문자열 하드코딩을 `label` 변수로 교체.
+
+- [ ] **Step 3.2: 기존 `_evaluate_macd_cross_window` 가 helper 호출하도록 변경**
+
+```python
+async def _evaluate_macd_cross_window(self, current_time):
+    """macd_cross 라이브 진입 평가 (14:31~15:00). 기존 단일 인스턴스 경로 유지."""
+    from config.strategy_settings import StrategySettings
+    mode = self._macd_cross_mode()
+    strategy = self.decision_engine.macd_cross_strategy if self.decision_engine else None
+    await self._evaluate_macd_cross_instance(
+        current_time,
+        strategy=strategy,
+        cfg_class=StrategySettings.MacdCross,
+        label='macd_cross',
+        mode=mode,
+    )
+```
+
+- [ ] **Step 3.3: helper `_count_open_paper_positions` / `_has_macd_cross_paper_buy_today` 가 label 인자 받도록 확장**
+
+기존 `_count_open_paper_positions(strategy: str)` 시그니처에 strategy 인자가 이미 있는지 확인:
+
+```bash
+grep -n "_count_open_paper_positions\|_has_macd_cross_buy_today" main.py
+```
+
+- 만약 `_count_open_paper_positions(self, strategy: str)` 가 이미 strategy 인자를 받으면 OK
+- 만약 strategy 하드코딩이면 인자 추가 필요
+
+`_has_macd_cross_buy_today(self, code)` → `_has_macd_cross_paper_buy_today(self, code, label='macd_cross')` 로 확장 (기본값 backwards-compat).
+
+쿼리 SQL 의 `WHERE strategy = 'macd_cross'` 를 `WHERE strategy = %s` 로 변경 + label 파라미터 바인드.
+
+- [ ] **Step 3.4: 회귀 테스트 — 기존 paper flow 그대로 통과**
+
+```bash
+python -m pytest tests/integration/test_macd_cross_paper_flow.py tests/strategies/test_macd_cross_*.py -v
+```
+Expected: 모두 passed (기존 13건 + Task 1, 2 신규 7건).
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add main.py
+git commit -m "$(cat <<'EOF'
+refactor(main): _evaluate_macd_cross_window 본체를 instance helper 로 추출
+
+paper 16/32 인스턴스 추가 대비. label 별 카운팅 + label 파라미터 전파.
+기존 14/34 라이브 경로 무영향 (helper 호출로 1:1 위임).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `_macd_cross_exit_dispatcher` 동일 추출 (regression-safe)
+
+**Files:**
+- Modify: `main.py` `_macd_cross_exit_dispatcher` 함수
+
+목적: D+2 청산 dispatcher 도 helper 화. 인자: strategy_label.
+
+- [ ] **Step 4.1: helper `_macd_cross_exit_instance(label, cfg_class, mode)` 추가**
+
+기존 dispatcher 본체를 (가능한 한) 1:1 복사 + `'macd_cross'` 문자열 하드코딩을 label 로 교체. 위치/이름 검색:
+
+```bash
+grep -n "_macd_cross_exit_dispatcher\|_macd_cross_live_exit_task" main.py
+```
+
+helper signature:
+```python
+async def _macd_cross_exit_instance(
+    self,
+    *,
+    label: str,
+    cfg_class,
+    mode: str,
+):
+    ...
+```
+
+- [ ] **Step 4.2: dispatcher 가 helper 호출하도록 변경**
+
+```python
+async def _macd_cross_exit_dispatcher(self, ...):
+    from config.strategy_settings import StrategySettings
+    mode = self._macd_cross_mode()
+    await self._macd_cross_exit_instance(
+        label='macd_cross',
+        cfg_class=StrategySettings.MacdCross,
+        mode=mode,
+    )
+```
+
+- [ ] **Step 4.3: 회귀**
+
+```bash
+python -m pytest tests/ -q
+```
+Expected: 270+ passed.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add main.py
+git commit -m "$(cat <<'EOF'
+refactor(main): _macd_cross_exit_dispatcher 도 instance helper 화
+
+paper 16/32 청산 추가 대비. label 별 청산 분리 가능.
+14/34 라이브 청산 경로 무영향.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `paper_macd_cross_strategy` 인스턴스 + pre_market 캐시 주입
+
+**Files:**
+- Modify: `main.py` `__init__` + pre_market 함수
+
+목적: PAPER_STRATEGY=='macd_cross_alt' 시 별도 MacdCrossStrategy(16/32) 인스턴스 생성 + 라이브와 동일 daily history 주입.
+
+- [ ] **Step 5.1: `__init__` 에 paper 인스턴스 생성**
+
+```bash
+grep -n "class RoboTrader" main.py | head -3
+```
+
+`__init__` 끝부분에 추가:
+```python
+        # 신규: macd_cross_alt (16/32) paper 인스턴스
+        from config.strategy_settings import StrategySettings
+        if StrategySettings.PAPER_STRATEGY == 'macd_cross_alt':
+            from core.strategies.macd_cross_strategy import MacdCrossStrategy
+            mca = StrategySettings.MacdCrossAlt
+            self.paper_macd_cross_strategy = MacdCrossStrategy(
+                fast=mca.FAST_PERIOD,
+                slow=mca.SLOW_PERIOD,
+                signal=mca.SIGNAL_PERIOD,
+                entry_hhmm_min=mca.ENTRY_HHMM_MIN,
+                entry_hhmm_max=mca.ENTRY_HHMM_MAX,
+                logger=self.logger,
+                label='macd_cross_alt',
+            )
+            self.logger.info(
+                f"[paper.macd_cross_alt] 인스턴스 생성 "
+                f"(fast={mca.FAST_PERIOD}, slow={mca.SLOW_PERIOD})"
+            )
+        else:
+            self.paper_macd_cross_strategy = None
+```
+
+- [ ] **Step 5.2: pre_market 의 `set_daily_history` 호출에 paper 도 추가**
+
+기존 `_pre_market_macd_cross_cache_warmup()` (또는 유사 함수) 찾기:
+```bash
+grep -n "set_daily_history\|macd_cross_strategy.*set_daily" main.py
+```
+
+기존 라이브 호출 직후에 paper 호출 추가:
+```python
+strategy = self.decision_engine.macd_cross_strategy
+if strategy is not None:
+    strategy.set_daily_history(stock_code, df_daily, today_yyyymmdd, prev_trading_value)
+# 신규 paper alt
+if self.paper_macd_cross_strategy is not None:
+    self.paper_macd_cross_strategy.set_daily_history(
+        stock_code, df_daily, today_yyyymmdd, prev_trading_value,
+    )
+```
+
+- [ ] **Step 5.3: 봇 시작 sanity (mocking)**
+
+```bash
+python -c "
+from config.strategy_settings import StrategySettings
+StrategySettings.PAPER_STRATEGY = 'macd_cross_alt'
+from main import RoboTrader
+# 실제 initialize 는 KIS API 필요 → import-only sanity
+print('import OK')
+print('paper attr exists:', hasattr(RoboTrader, '__init__'))
+"
+```
+Expected: 'import OK' + 'paper attr exists: True'.
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add main.py
+git commit -m "$(cat <<'EOF'
+feat(main): paper_macd_cross_strategy (16/32) 인스턴스 + pre_market 캐시 주입
+
+PAPER_STRATEGY='macd_cross_alt' 활성 시 라이브 14/34 옆에 paper 16/32
+MacdCrossStrategy 생성. 매일 pre_market 에서 양 인스턴스 모두 daily
+history → MACD hist 캐시 갱신.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: paper 진입 평가 호출 추가
+
+**Files:**
+- Modify: `main.py` `_evaluate_macd_cross_window` 또는 `_system_monitoring_task` 호출 지점
+
+목적: 14:31~15:00 시점에 paper 인스턴스도 평가.
+
+- [ ] **Step 6.1: `_evaluate_macd_cross_window` 끝에 paper 분기 호출 추가**
+
+Task 3 에서 만든 helper 를 paper 인스턴스로도 호출:
+
+```python
+async def _evaluate_macd_cross_window(self, current_time):
+    from config.strategy_settings import StrategySettings
+    mode = self._macd_cross_mode()
+    strategy = self.decision_engine.macd_cross_strategy if self.decision_engine else None
+    await self._evaluate_macd_cross_instance(
+        current_time,
+        strategy=strategy,
+        cfg_class=StrategySettings.MacdCross,
+        label='macd_cross',
+        mode=mode,
+    )
+    # 신규: paper 16/32 alt 평가 — 라이브와 분리, 항상 'virtual' mode
+    if (StrategySettings.PAPER_STRATEGY == 'macd_cross_alt'
+            and self.paper_macd_cross_strategy is not None):
+        await self._evaluate_macd_cross_instance(
+            current_time,
+            strategy=self.paper_macd_cross_strategy,
+            cfg_class=StrategySettings.MacdCrossAlt,
+            label='macd_cross_alt',
+            mode='virtual',
+        )
+```
+
+- [ ] **Step 6.2: 회귀 — 기존 paper flow 그대로 통과**
+
+```bash
+python -m pytest tests/ -q
+```
+
+- [ ] **Step 6.3: Commit**
+
+```bash
+git add main.py
+git commit -m "$(cat <<'EOF'
+feat(main): _evaluate_macd_cross_window 에 paper alt 분기 추가
+
+라이브 14/34 평가 직후 paper 16/32 helper 호출 (mode='virtual').
+PAPER_STRATEGY!='macd_cross_alt' 시 호출 안 함.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: paper 청산 dispatcher 호출 추가
+
+**Files:**
+- Modify: `main.py` `_macd_cross_exit_dispatcher`
+
+목적: D+2 morning + EOD 청산 시 paper 인스턴스도 처리.
+
+- [ ] **Step 7.1: dispatcher 끝에 paper 분기 호출 추가**
+
+Task 4 에서 만든 helper 를 paper 인자로도 호출:
+
+```python
+async def _macd_cross_exit_dispatcher(self, ...):
+    from config.strategy_settings import StrategySettings
+    mode = self._macd_cross_mode()
+    await self._macd_cross_exit_instance(
+        label='macd_cross',
+        cfg_class=StrategySettings.MacdCross,
+        mode=mode,
+    )
+    if StrategySettings.PAPER_STRATEGY == 'macd_cross_alt':
+        await self._macd_cross_exit_instance(
+            label='macd_cross_alt',
+            cfg_class=StrategySettings.MacdCrossAlt,
+            mode='virtual',
+        )
+```
+
+- [ ] **Step 7.2: 회귀**
+
+```bash
+python -m pytest tests/ -q
+```
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add main.py
+git commit -m "$(cat <<'EOF'
+feat(main): _macd_cross_exit_dispatcher 에 paper alt 분기 추가
+
+라이브 14/34 청산 직후 paper 16/32 helper 호출.
+D+2 / EOD 청산 모두 동일 흐름.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: 텔레그램 EOD dual KPI 보고
+
+**Files:**
+- Modify: `main.py` `_macd_cross_paper_telegram_report` (또는 유사 함수)
+
+목적: 일일 EOD 텔레그램 메시지에 macd_cross / macd_cross_alt 두 섹션 출력.
+
+- [ ] **Step 8.1: 기존 KPI 보고 함수 위치 확인**
+
+```bash
+grep -n "MacdCrossKpi\|macd_cross.*paper.*report\|telegram.*kpi" main.py
+```
+
+- [ ] **Step 8.2: dual 섹션 출력으로 확장**
+
+기존 한 섹션 출력 코드를 두 번 호출하도록:
+
+```python
+async def _macd_cross_paper_telegram_report(self, current_time):
+    from config.strategy_settings import StrategySettings
+    from core.strategies.macd_cross_kpi import MacdCrossKpi
+
+    sections = []
+
+    # 라이브 (real)
+    if StrategySettings.ACTIVE_STRATEGY == 'macd_cross':
+        df_real = self._fetch_macd_cross_real_trades()  # 기존 helper 또는 신규
+        kpi_real = MacdCrossKpi(StrategySettings.MacdCross.VIRTUAL_CAPITAL).compute(df_real)
+        sections.append(self._format_macd_cross_kpi_section('macd_cross (real)', kpi_real))
+
+    # 신규 paper alt
+    if StrategySettings.PAPER_STRATEGY == 'macd_cross_alt':
+        df_alt = self.db_manager.fetch_virtual_trades(strategy='macd_cross_alt')
+        kpi_alt = MacdCrossKpi(StrategySettings.MacdCrossAlt.VIRTUAL_CAPITAL).compute(df_alt)
+        sections.append(self._format_macd_cross_kpi_section('macd_cross_alt (paper)', kpi_alt))
+
+    msg = "\n\n".join(sections)
+    await self.telegram_bot.send_message(msg)
+```
+
+- [ ] **Step 8.3: `db_manager.fetch_virtual_trades(strategy='macd_cross_alt')` 가 있는지 확인**
+
+```bash
+grep -n "def fetch_virtual\|def get_virtual.*trades\|strategy.*macd_cross" db/database_manager.py
+```
+
+기존 `get_virtual_open_positions` 외에 paper KPI 용 trade rows 쿼리가 이미 있는지 확인. 없으면 신규 추가:
+
+```python
+def fetch_virtual_trades(self, strategy: str) -> pd.DataFrame:
+    """가상 매매 trade rows (BUY-SELL pair) 반환. KPI 입력용."""
+    query = '''
+        SELECT b.timestamp AS buy_time, s.timestamp AS sell_time, s.profit_loss AS pnl
+        FROM virtual_trading_records s
+        JOIN virtual_trading_records b ON s.buy_record_id = b.id
+        WHERE s.action = 'SELL' AND s.strategy = %s AND b.strategy = %s
+        ORDER BY s.timestamp ASC
+    '''
+    with self._pool_obj.connection() as conn:
+        return pd.read_sql_query(query, conn, params=(strategy, strategy))
+```
+
+(기존 동일 쿼리가 있으면 재사용; 신규 추가 시 unit test 추가).
+
+- [ ] **Step 8.4: 회귀**
+
+```bash
+python -m pytest tests/ -q
+```
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add main.py db/database_manager.py
+git commit -m "$(cat <<'EOF'
+feat(main): EOD 텔레그램 보고에 paper alt KPI 섹션 추가
+
+macd_cross (real) + macd_cross_alt (paper) 두 KPI 분리 출력.
+strategy 컬럼 필터로 가상매매 분리 집계.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: paper alt flow E2E integration test
+
+**Files:**
+- Test: `tests/integration/test_macd_cross_alt_paper_flow.py` (신규)
+
+목적: 시그널 hit → save_virtual_buy(strategy='macd_cross_alt') → D+2 청산 → KPI 집계 풀스택 검증.
+
+- [ ] **Step 9.1: 기존 paper flow 테스트 패턴 확인**
+
+```bash
+cat tests/integration/test_macd_cross_paper_flow.py | head -60
+```
+
+- [ ] **Step 9.2: alt flow 테스트 작성**
+
+`tests/integration/test_macd_cross_alt_paper_flow.py`:
+
+```python
+"""macd_cross_alt (16/32) paper flow E2E.
+
+라이브 14/34 와 paper 16/32 가 같은 봇 인스턴스에서 동시 동작 — paper 만
+가상매매로 routing 되는지, KPI 집계가 strategy='macd_cross_alt' 필터로
+분리되는지 검증.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from config.strategy_settings import StrategySettings
+from core.strategies.macd_cross_kpi import MacdCrossKpi
+from core.strategies.macd_cross_strategy import MacdCrossStrategy
+
+
+@pytest.fixture
+def alt_strategy():
+    return MacdCrossStrategy(
+        fast=16, slow=32, signal=12, entry_hhmm_min=1431,
+        label='macd_cross_alt',
+    )
+
+
+def test_alt_strategy_label_propagates_to_logging(alt_strategy):
+    """label 'macd_cross_alt' 가 인스턴스에 보존."""
+    assert alt_strategy.label == 'macd_cross_alt'
+
+
+def test_alt_signal_independent_from_live():
+    """동일 daily history 입력 시 14/34 와 16/32 의 prev_hist 가 다름."""
+    import pandas as pd, numpy as np
+    np.random.seed(42)
+    n = 60
+    df = pd.DataFrame({
+        "trade_date": [f"202509{i:02d}" for i in range(1, n+1)],
+        "close": 1000 + np.cumsum(np.random.randn(n) * 5),
+    })
+    live = MacdCrossStrategy(fast=14, slow=34, signal=12, label='macd_cross')
+    paper = MacdCrossStrategy(fast=16, slow=32, signal=12, label='macd_cross_alt')
+
+    live.set_daily_history("000001", df, "20251102")
+    paper.set_daily_history("000001", df, "20251102")
+
+    live_hist = live.get_cached_hist("000001")
+    paper_hist = paper.get_cached_hist("000001")
+
+    # 다른 fast/slow 로 다른 hist 값 → cache 분리 검증
+    assert live_hist != paper_hist
+
+
+def test_kpi_filter_by_strategy_label(monkeypatch):
+    """KPI 가 'macd_cross_alt' strategy filter 시 alt rows 만 집계."""
+    import pandas as pd
+
+    df_alt_only = pd.DataFrame({
+        "buy_time": pd.to_datetime(["2026-05-12 14:31", "2026-05-13 14:31"]),
+        "sell_time": pd.to_datetime(["2026-05-14 09:01", "2026-05-15 09:01"]),
+        "pnl": [50000.0, -30000.0],
+    })
+    kpi = MacdCrossKpi(virtual_capital=10_000_000)
+    metrics = kpi.compute(df_alt_only)
+    assert metrics["trade_count"] == 2
+    assert metrics["return"] == pytest.approx((50000 - 30000) / 10_000_000)
+    gates = kpi.evaluate_gates(metrics)
+    # 표본 적어 calmar/return 등 통과/탈락은 의미 없음 — 게이트 평가 동작만 확인
+    assert "all_pass" in gates
+
+
+@pytest.mark.skip(reason="Requires KIS API mock + DB fixture — run manually after Task 8")
+def test_full_flow_signal_to_kpi():
+    """E2E: signal hit → save_virtual_buy(strategy='macd_cross_alt') → D+2 청산
+    → fetch_virtual_trades('macd_cross_alt') → KPI 집계.
+
+    DB fixture + KIS mock 준비 후 활성화.
+    """
+    pass
+```
+
+- [ ] **Step 9.3: 테스트 실행**
+
+```bash
+python -m pytest tests/integration/test_macd_cross_alt_paper_flow.py -v
+```
+Expected: 3 passed (skipped 1).
+
+- [ ] **Step 9.4: 전체 회귀**
+
+```bash
+python -m pytest tests/ -q
+```
+Expected: 270+ passed (1 skipped).
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add tests/integration/test_macd_cross_alt_paper_flow.py
+git commit -m "$(cat <<'EOF'
+test(integration): macd_cross_alt paper flow E2E
+
+label 분리, 시그널 독립성, KPI filter 검증. 풀스택 E2E 는
+KIS mock + DB fixture 준비 후 활성화 (현재 skip).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: 운영 문서 + PAPER_STRATEGY 활성화 + 최종 회귀
+
+**Files:**
+- Modify: `docs/macd_cross_operation.md`
+- Modify: `config/strategy_settings.py` (`PAPER_STRATEGY = 'macd_cross_alt'`)
+
+목적: 운영 노트 갱신 + 활성화 스위치 ON + 최종 회귀.
+
+- [ ] **Step 10.1: `docs/macd_cross_operation.md` 운영 노트 추가**
+
+`docs/macd_cross_operation.md` 끝부분에 신규 섹션 추가:
+
+```markdown
+## macd_cross_alt (16/32) Paper 검증 — 2026-05-09 ~
+
+**목적**: MV-A 멀티버스 결과 (4ds-avg calmar 65→128, +95%) 의 OOS 재현성 검증.
+
+**활성화 조건**:
+- `StrategySettings.PAPER_STRATEGY = 'macd_cross_alt'`
+- 라이브 14/34 (`ACTIVE_STRATEGY='macd_cross'`, `VIRTUAL_ONLY=False`) 그대로 유지
+- 양 인스턴스가 같은 universe top 30 공유 (KIS API 1회 호출)
+
+**종료 조건**: 4주 또는 30 trades 도달 시 (먼저 충족).
+
+**승격 게이트** (모두 통과 시 swap PR — `MacdCross.FAST_PERIOD = 16, SLOW_PERIOD = 32`):
+1. paper Calmar ≥ 30
+2. paper return ≥ 0
+3. paper MDD ≤ 5%
+4. paper 승률 ≥ 50%
+5. top1 trade P&L 점유율 ≤ 60%
+6. max consecutive losses ≤ 4
+
+**중도 안전정지**: 누적 -5% 또는 5연패 → `PAPER_STRATEGY=None` 자동 정지.
+
+**모니터링**:
+- 일일 EOD 텔레그램 보고에 [macd_cross (real)] / [macd_cross_alt (paper)] 두 섹션 출력
+- 운영 로그: `grep "macd_cross_alt" logs/trading_YYYYMMDD.log`
+
+**스펙/플랜**:
+- Spec: `docs/superpowers/specs/2026-05-09-macd-cross-alt-paper-validation-design.md`
+- Plan: `docs/superpowers/plans/2026-05-09-macd-cross-alt-paper-validation.md`
+```
+
+- [ ] **Step 10.2: PAPER_STRATEGY 활성화**
+
+`config/strategy_settings.py`:
+```python
+    PAPER_STRATEGY = 'macd_cross_alt'   # None → 'macd_cross_alt' 활성화
+```
+
+- [ ] **Step 10.3: 최종 회귀**
+
+```bash
+python -m pytest tests/ -q
+```
+Expected: 270+ passed.
+
+- [ ] **Step 10.4: 봇 dry-run sanity**
+
+```bash
+python -c "
+from config.strategy_settings import validate_settings, StrategySettings
+print('PAPER_STRATEGY =', StrategySettings.PAPER_STRATEGY)
+print('validate_settings:', validate_settings())
+print('MacdCrossAlt.FAST_PERIOD =', StrategySettings.MacdCrossAlt.FAST_PERIOD)
+print('MacdCrossAlt.SLOW_PERIOD =', StrategySettings.MacdCrossAlt.SLOW_PERIOD)
+"
+```
+Expected: 정상 출력 + `validate_settings: True`.
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add docs/macd_cross_operation.md config/strategy_settings.py
+git commit -m "$(cat <<'EOF'
+feat(ops): macd_cross_alt (16/32) paper 활성화
+
+PAPER_STRATEGY=None → 'macd_cross_alt'. 라이브 14/34 실거래 그대로 유지.
+운영 노트 + 승격 게이트 + 모니터링 가이드 추가.
+
+종료: 4주 또는 30 trades. 통과 시 swap PR 별도 진행.
+
+Spec docs/superpowers/specs/2026-05-09-macd-cross-alt-paper-validation-design.md.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review (이미 적용)
+
+- 모든 task 가 spec §1~10 cover (config §4.1, dispatch §4.2, instance label §4.3, KPI/DB §4.4-§4.5, data flow §5, isolation §6, testing §7, rollback §8)
+- 모든 step 에 실제 code/command/expected output 포함, "TBD/TODO" 없음
+- type / 함수명 일관성: `MacdCrossAlt`, `paper_macd_cross_strategy`, `_evaluate_macd_cross_instance`, `_macd_cross_exit_instance`, `label='macd_cross_alt'` 전반 동일
+- DB 스키마 변경 없음 — 기존 `virtual_trading_records.strategy` 컬럼 + DataFrame-driven KPI 재사용 (spec §4.5 정정)
+- 라이브 14/34 경로는 helper 추출 위임 외 변경 0 → 회귀 위험 낮음

--- a/docs/superpowers/specs/2026-05-09-macd-cross-alt-paper-validation-design.md
+++ b/docs/superpowers/specs/2026-05-09-macd-cross-alt-paper-validation-design.md
@@ -1,0 +1,220 @@
+# macd_cross_alt (16/32) 페이퍼 검증 설계
+
+작성일: 2026-05-09
+관련 산출물:
+- `backtests/reports/macd_cross_mv/param_grid/summary.md` (MV-A 멀티버스 결과)
+- `backtests/reports/macd_cross_mv/param_grid/cells.csv`
+- `docs/superpowers/specs/2026-05-07-macd-cross-multiverse-design.md` (MV 설계서)
+- `docs/superpowers/specs/2026-04-26-macd-cross-live-integration-design.md` (기존 paper 통합 설계 — 본 spec 의 패턴 baseline)
+
+## 1. 배경
+
+MV-A 멀티버스 (360 cell × 4 dataset = 1,440 evaluation, 2026-05-08 commit `133828c3`) 결과:
+
+- 현재 라이브 파라미터 `fast=14, slow=34, signal=12, entry_hhmm_min=1431` 의 4ds-avg Calmar = 65.44 (23/360 위, top 6%, plateau robust)
+- **글로벌 best**: `fast=16, slow=32, signal=12, entry_hhmm_min=1430` → 4ds-avg Calmar = **127.69** (현 라이브 대비 +95%)
+- 인접 36 cell (best ±1 step) 86% 가 calmar > 30 → 단일 cherry-pick 아님
+- Fragility (top1>0.6) 측면에서도 16/32 영역이 14/34 보다 낮음
+
+backtest 우월성은 강하지만 **단일 OOS fold (39 trading days)** 만으로는 라이브 즉시 swap 결정에 부족. 기존 macd_cross paper 통합 (2026-04-26) 와 동일 패턴으로 **4주 / 30 trades paper 검증** 후 승격 결정.
+
+라이브 14/34 가 현재 실거래 운영 중 (2026-04-27~) 이라 paper 16/32 는 **alongside 가상매매** 로 띄움 — 라이브 수익 손실 없이 검증 가능.
+
+## 2. 핵심 결정 (인터뷰 결과)
+
+| 항목 | 결정 | 근거 |
+|------|------|------|
+| 공존 모델 | **나란히 운영** — 라이브 14/34 (실거래) 유지 + paper 16/32 (가상) | 4주간 라이브 수익 손실 없이 검증 |
+| 구현 접근 | **별도 파라미터 클래스** (`MacdCrossAlt`) | 라이브와 paper 완전 격리, 회귀 위험 0, 기존 dual-strategy dispatch 패턴 일관성 |
+| 페이퍼 기간 | **4주 또는 30 trades 도달 시 (먼저 충족)** — 기존 macd_cross paper 동일 | OOS fold (39 days) 동등 표본 확보 |
+| 승격 게이트 | 6 KPI 게이트 — 기존 macd_cross paper 동일 | 일관성 유지, 새 임계값 도입은 추가 검증 부담 |
+| 승격 시 액션 | **In-place swap** — `MacdCross` 클래스 값 16/32 로 일괄 교체, `MacdCrossAlt` + `PAPER_STRATEGY` 삭제 | 단일 전략 운영 일관성 |
+| 위험 오버레이 | **G1 — 백테스트 100% 재현** (SL/TP 없음, 라이브 필터 미적용, hold_days=2 시간청산만) | MV-A 결과의 OOS 재현성 검증이 목적, overlay 도입 시 평가 대상 흐림 |
+
+## 3. 승격 게이트 (paper 종료 시 모두 충족 시 회의 진입)
+
+기존 macd_cross paper 와 동일:
+
+1. paper Calmar ≥ 30
+2. paper return ≥ 0
+3. paper MDD ≤ 5%
+4. paper 승률 ≥ 50%
+5. top1 trade P&L 점유율 ≤ 60%
+6. max consecutive losses ≤ 4
+
+**중도 안전 정지** (paper 즉시 중단):
+- 누적 가상손실 ≥ -5%
+- 연속 손실 ≥ 5건
+
+게이트 통과 시 액션:
+
+| 결과 | 액션 |
+|------|------|
+| 6/6 통과 | swap PR — `MacdCross.FAST_PERIOD = 16, SLOW_PERIOD = 32` 일괄 교체. `MacdCrossAlt` + `PAPER_STRATEGY` 삭제. paper KPI / virtual records 보존 (사후 분석용) |
+| 5/6 통과 | 사람 검토 — 미통과 KPI 가 critical 인지 판단. 추가 4주 paper 또는 revert |
+| 4 이하 통과 | revert — `MacdCrossAlt` 비활성, paper 결과 archive. MV-A top cell list 의 다른 후보 (예: 14/36 calmar=97) 후속 검토 |
+| 중도 안전정지 발동 | `PAPER_STRATEGY=None` 자동 정지, 사람 검토 |
+
+## 4. 아키텍처 변경
+
+### 4.1 신규 파라미터 클래스
+
+`config/strategy_settings.py` 에 `MacdCross` 옆에 `MacdCrossAlt` 신설. 기존 `MacdCross` 는 일절 수정 없음.
+
+```python
+class StrategySettings:
+    ACTIVE_STRATEGY = 'macd_cross'                 # 실거래 14/34 그대로
+    PAPER_STRATEGY = 'macd_cross_alt'              # 신규 paper key
+
+    class MacdCross:                               # 라이브 (변경 없음)
+        FAST_PERIOD = 14
+        SLOW_PERIOD = 34
+        SIGNAL_PERIOD = 12
+        ENTRY_HHMM_MIN = 1431
+        ENTRY_HHMM_MAX = 1500
+        HOLD_DAYS = 2
+        VIRTUAL_CAPITAL = 10_000_000
+        BUY_BUDGET_RATIO = 0.20
+        MAX_DAILY_POSITIONS = 5
+        UNIVERSE_TOP_N = 30
+        APPLY_LIVE_OVERLAY = False
+        ALLOWED_WEEKDAYS = [0, 1, 2, 3, 4]
+        VIRTUAL_ONLY = False                       # 실거래
+
+    class MacdCrossAlt:                            # 신규 paper-only
+        """16/32 paper 검증 (MV-A best). docs/superpowers/specs/2026-05-09-macd-cross-alt-paper-validation-design.md."""
+        FAST_PERIOD = 16
+        SLOW_PERIOD = 32
+        SIGNAL_PERIOD = 12
+        ENTRY_HHMM_MIN = 1431                      # 라이브와 동일 (next_bar_open 정렬)
+        ENTRY_HHMM_MAX = 1500
+        HOLD_DAYS = 2
+        VIRTUAL_CAPITAL = 10_000_000
+        BUY_BUDGET_RATIO = 0.20
+        MAX_DAILY_POSITIONS = 5
+        UNIVERSE_TOP_N = 30                        # 라이브와 동일 universe 공유
+        APPLY_LIVE_OVERLAY = False
+        ALLOWED_WEEKDAYS = [0, 1, 2, 3, 4]
+        VIRTUAL_ONLY = True                        # paper 는 항상 가상
+
+    # validate_settings 에 macd_cross_alt 동일 가드 추가
+```
+
+### 4.2 Dispatch 분기 추가
+
+main.py 의 5개 분기에 `PAPER_STRATEGY=='macd_cross_alt'` 케이스 추가:
+
+| 위치 | 변경 |
+|------|------|
+| `__init__` (universe preload) | universe top 30 은 **단일 preload 결과를 두 인스턴스가 공유** (KIS API 중복 호출 방지). `MacdCrossAlt.UNIVERSE_TOP_N` 와 `MacdCross.UNIVERSE_TOP_N` 가 동일 (30) 한지 `validate_settings` 에서 강제 |
+| `__init__` (FundManager) | paper 인스턴스용 `VirtualFundManager(MacdCrossAlt.VIRTUAL_CAPITAL)` 추가 |
+| `_evaluate_macd_cross_window` | 두 인스턴스 (`MacdCrossStrategy(cfg=MacdCross)` / `MacdCrossStrategy(cfg=MacdCrossAlt)`) 각각 시그널 평가 → 라우팅 |
+| `_macd_cross_exit_dispatcher` | 보유 포지션 분기 — strategy_label 로 라이브/paper 구분 후 각각 청산 |
+| 텔레그램 EOD 보고 | 두 KPI 인스턴스 출력 (label='macd_cross' real / label='macd_cross_alt' paper) |
+
+### 4.3 MacdCrossStrategy 인스턴스화 변경
+
+현재 `core/strategies/macd_cross_strategy.py` 의 `MacdCrossStrategy.__init__` 가 `StrategySettings.MacdCross` 를 하드코딩으로 import. **변경**: 생성자가 cfg 클래스를 인자로 받도록.
+
+```python
+class MacdCrossStrategy:
+    def __init__(self, cfg=None, label='macd_cross'):
+        self.cfg = cfg or StrategySettings.MacdCross
+        self.label = label                       # KPI / 로깅용
+        self.fast = self.cfg.FAST_PERIOD
+        ...
+```
+
+main.py 에서:
+```python
+self.live_macd = MacdCrossStrategy(cfg=StrategySettings.MacdCross,    label='macd_cross')
+self.paper_macd = MacdCrossStrategy(cfg=StrategySettings.MacdCrossAlt, label='macd_cross_alt')  # PAPER_STRATEGY 활성화 시만
+```
+
+### 4.4 KPI 집계 분리
+
+`core/strategies/macd_cross_kpi.py` 의 `MacdCrossKpi.__init__` 에 `strategy_label` 인자 추가 — DB 쿼리 시 필터로 사용.
+
+| 인스턴스 | 데이터 소스 | 게이트 평가 |
+|----------|-------------|-------------|
+| `MacdCrossKpi(label='macd_cross')` | `real_trading_records WHERE strategy='macd_cross'` | 라이브 KPI |
+| `MacdCrossKpi(label='macd_cross_alt')` | `virtual_trading_records WHERE strategy_label='macd_cross_alt'` | paper 게이트 평가 (4주/30 trades 통과 판정) |
+
+### 4.5 DB 스키마 변경
+
+`virtual_trading_records` 테이블에 `strategy_label TEXT NOT NULL DEFAULT 'macd_cross'` 컬럼 추가.
+
+마이그레이션:
+- `db/migrations/202605091200_add_strategy_label.sql` (신규)
+- 기존 row 는 모두 'macd_cross' 로 백필 (현재 macd_cross paper 만 가상매매 사용 중)
+- `database_manager.insert_virtual_trade()` signature 에 `strategy_label='macd_cross'` 기본 인자 추가
+
+## 5. 데이터 흐름
+
+```
+config 로드 (StrategySettings, validate_settings 포함)
+  ├─ ACTIVE_STRATEGY='macd_cross'     → MacdCross (14/34)  [실거래]
+  └─ PAPER_STRATEGY='macd_cross_alt'  → MacdCrossAlt (16/32) [가상]
+
+main._system_monitoring_task → _evaluate_macd_cross_window
+  ├─ live_macd (cfg=MacdCross, label='macd_cross')
+  │   → 14:31 시그널 hit → execute_buy (실주문) → real_trading_records (strategy='macd_cross')
+  └─ paper_macd (cfg=MacdCrossAlt, label='macd_cross_alt')
+      → 14:31 시그널 hit → execute_virtual_buy → virtual_trading_records (strategy_label='macd_cross_alt')
+
+청산 (_macd_cross_exit_dispatcher)
+  ├─ 라이브 보유: D+2 morning / EOD → 실주문 시장가 매도
+  └─ paper 보유 : 동일 dispatcher 호출, virtual_trading_manager 가 가상 청산
+
+KPI 집계 (일일 EOD 텔레그램 보고)
+  ├─ MacdCrossKpi('macd_cross')      → real_trading_records
+  └─ MacdCrossKpi('macd_cross_alt')  → virtual_trading_records WHERE strategy_label='macd_cross_alt'
+
+텔레그램 출력:
+  [macd_cross] real:  trades=N1, win=W1%, calmar=C1, MDD=M1
+  [macd_cross_alt] paper: trades=N2, win=W2%, calmar=C2, MDD=M2
+  [Δ] alt vs real: +<diff>%
+```
+
+## 6. 격리 보장
+
+| 자원 | 격리 방식 |
+|------|-----------|
+| 자금 (capital pool) | `FundManager` (real) ↔ `VirtualFundManager` (virtual) — 완전 분리 |
+| 포지션 (보유 종목) | real → KIS 계좌 / virtual → in-memory ledger — 충돌 X |
+| 종목 한도 | 각 인스턴스 5종목 독립 카운트 |
+| KPI 추적 | DB 쿼리 시 `strategy='macd_cross'` (real) vs `strategy_label='macd_cross_alt'` (virtual) 으로 필터 |
+| 시그널 평가 | 두 인스턴스가 같은 분봉 데이터를 받지만 MACD 계산 파라미터 다름 → 자연스럽게 다른 시그널 발생 |
+
+**동시 매수 케이스**: 라이브 14/34 hit + paper 16/32 hit 둘 다 14:31 → 라이브 실주문 + paper 가상 buy 동시 기록. 자원 충돌 없음.
+
+## 7. Testing 전략
+
+| 테스트 | 위치 | 검증 |
+|--------|------|------|
+| Unit: `MacdCrossAlt` 인스턴스화 + signal 계산 | `tests/strategies/test_macd_cross_alt.py` (신규) | fast=16/slow=32 MACD hist 정확성 |
+| Parity: backtest signal == live paper signal (16/32) | `tests/strategies/test_macd_cross_alt_signal_parity.py` (신규) | 4-dataset OOS 분봉으로 backtest vs adapter 비교 |
+| Integration: paper flow E2E | `tests/integration/test_macd_cross_alt_paper_flow.py` (신규) | 시그널 hit → virtual_buy → D+2 청산 → KPI 집계 풀스택 |
+| Regression: 기존 macd_cross 라이브 무영향 | 기존 270+ tests | 14/34 라이브 경로 변경 없음 확인 |
+| Manual: 텔레그램 보고 출력 | 운영 첫날 | 두 strategy_label KPI 분리 표시 확인 |
+
+## 8. 롤백 안전망
+
+- `PAPER_STRATEGY=None` 으로 즉시 paper 정지 가능 (기존 인프라 재사용)
+- DB `strategy_label` 컬럼은 NOT NULL DEFAULT 'macd_cross' → 신규 컬럼이 기존 레코드와 호환
+- `MacdCrossStrategy(cfg=...)` 변경은 기본값을 `StrategySettings.MacdCross` 로 둠 → cfg 인자 미지정 시 기존 동작 그대로
+
+## 9. 범위 밖 (Out of Scope)
+
+- Sub-project B (reversal-only overlay paper) — 별도 spec, A 통과 또는 4주 후 진행
+- Sub-project C (fold2 regime filter) — 별도 spec, 병행 진행 가능
+- Stage 2 16/32 재훈련 (단일 16/32 cell 의 1000 trial 재 fine-tune) — paper 만으로 부족 시 후속
+- Dual-live (14/34 + 16/32 동시 실거래) — paper 통과 후 별도 결정
+
+## 10. 산출물
+
+- 코드: `config/strategy_settings.py` 수정, `core/strategies/macd_cross_strategy.py` cfg 주입 변경, `core/strategies/macd_cross_kpi.py` label 인자, `core/virtual_trading_manager.py` strategy_label 추적, `db/database_manager.py` 컬럼 추가, `main.py` dispatch 5곳, DB 마이그레이션 SQL 1개
+- 테스트: 신규 3개 (`test_macd_cross_alt.py`, `test_macd_cross_alt_signal_parity.py`, `test_macd_cross_alt_paper_flow.py`)
+- 문서: `docs/macd_cross_operation.md` 운영 노트 추가
+
+승격 결정 후 별도 swap PR 로 16/32 라이브 적용 + paper 비활성화.

--- a/docs/superpowers/specs/2026-05-09-macd-cross-alt-paper-validation-design.md
+++ b/docs/superpowers/specs/2026-05-09-macd-cross-alt-paper-validation-design.md
@@ -140,14 +140,16 @@ self.paper_macd = MacdCrossStrategy(cfg=StrategySettings.MacdCrossAlt, label='ma
 | `MacdCrossKpi(label='macd_cross')` | `real_trading_records WHERE strategy='macd_cross'` | 라이브 KPI |
 | `MacdCrossKpi(label='macd_cross_alt')` | `virtual_trading_records WHERE strategy_label='macd_cross_alt'` | paper 게이트 평가 (4주/30 trades 통과 판정) |
 
-### 4.5 DB 스키마 변경
+### 4.5 DB 스키마 (변경 없음)
 
-`virtual_trading_records` 테이블에 `strategy_label TEXT NOT NULL DEFAULT 'macd_cross'` 컬럼 추가.
+`virtual_trading_records.strategy` 컬럼이 **이미 존재** (기존 `save_virtual_buy/sell` signature 의 `strategy` 인자가 그대로 저장됨). 마이그레이션 불필요.
 
-마이그레이션:
-- `db/migrations/202605091200_add_strategy_label.sql` (신규)
-- 기존 row 는 모두 'macd_cross' 로 백필 (현재 macd_cross paper 만 가상매매 사용 중)
-- `database_manager.insert_virtual_trade()` signature 에 `strategy_label='macd_cross'` 기본 인자 추가
+호출자만 변경:
+- 라이브 매수 (실 거래) → `real_trading_records` 별도 테이블 (영향 없음)
+- 기존 paper macd_cross → `save_virtual_buy(..., strategy='macd_cross', ...)` (변경 없음)
+- 신규 paper macd_cross_alt → `save_virtual_buy(..., strategy='macd_cross_alt', ...)` (호출 인자만 다름)
+
+KPI 쿼리는 `SELECT ... FROM virtual_trading_records WHERE strategy='macd_cross_alt'` 로 분리.
 
 ## 5. 데이터 흐름
 
@@ -213,7 +215,7 @@ KPI 집계 (일일 EOD 텔레그램 보고)
 
 ## 10. 산출물
 
-- 코드: `config/strategy_settings.py` 수정, `core/strategies/macd_cross_strategy.py` cfg 주입 변경, `core/strategies/macd_cross_kpi.py` label 인자, `core/virtual_trading_manager.py` strategy_label 추적, `db/database_manager.py` 컬럼 추가, `main.py` dispatch 5곳, DB 마이그레이션 SQL 1개
+- 코드: `config/strategy_settings.py` 수정 (MacdCrossAlt 추가), `core/strategies/macd_cross_strategy.py` label 파라미터 추가, `main.py` dispatch 분기 추출 + paper 인스턴스 + 호출 5곳, 텔레그램 EOD dual KPI. KPI/DB 모듈 변경 없음 (기존 `strategy` 컬럼 + DataFrame-driven KPI 재사용).
 - 테스트: 신규 3개 (`test_macd_cross_alt.py`, `test_macd_cross_alt_signal_parity.py`, `test_macd_cross_alt_paper_flow.py`)
 - 문서: `docs/macd_cross_operation.md` 운영 노트 추가
 

--- a/main.py
+++ b/main.py
@@ -116,6 +116,33 @@ class DayTradingBot:
             _fm_ratio = self.config.order_management.buy_budget_ratio
         self.fund_manager = FundManager(buy_budget_ratio=_fm_ratio)
         self.chart_generator = None  # 🆕 장 마감 후 차트 생성기 (지연 초기화)
+
+        # 신규: macd_cross_alt (16/32) paper 인스턴스 (PAPER_STRATEGY 활성 시에만)
+        # Spec: docs/superpowers/specs/2026-05-09-macd-cross-alt-paper-validation-design.md
+        try:
+            from config.strategy_settings import StrategySettings as _SS_PA
+            if _SS_PA.PAPER_STRATEGY == 'macd_cross_alt':
+                from core.strategies.macd_cross_strategy import MacdCrossStrategy
+                mca = _SS_PA.MacdCrossAlt
+                self.paper_macd_cross_strategy = MacdCrossStrategy(
+                    fast=mca.FAST_PERIOD,
+                    slow=mca.SLOW_PERIOD,
+                    signal=mca.SIGNAL_PERIOD,
+                    entry_hhmm_min=mca.ENTRY_HHMM_MIN,
+                    entry_hhmm_max=mca.ENTRY_HHMM_MAX,
+                    logger=self.logger,
+                    label='macd_cross_alt',
+                )
+                self.logger.info(
+                    f"[paper.macd_cross_alt] 인스턴스 생성 "
+                    f"(fast={mca.FAST_PERIOD}, slow={mca.SLOW_PERIOD}, "
+                    f"signal={mca.SIGNAL_PERIOD})"
+                )
+            else:
+                self.paper_macd_cross_strategy = None
+        except Exception as _paper_e:
+            self.logger.warning(f"[paper.macd_cross_alt] 인스턴스 생성 실패: {_paper_e}")
+            self.paper_macd_cross_strategy = None
         
         
         # 신호 핸들러 등록
@@ -1441,8 +1468,11 @@ class DayTradingBot:
             return
 
         codes = [s.code for s in candidates]
+        # 신규 paper alt: 활성 시 라이브와 동일 daily history 를 paper 인스턴스에도 주입
+        paper_strategy = getattr(self, 'paper_macd_cross_strategy', None)
         cached_count = await loop.run_in_executor(
-            None, self._load_macd_cross_daily_batch, codes, today_str, strategy
+            None, self._load_macd_cross_daily_batch,
+            codes, today_str, strategy, paper_strategy,
         )
 
         self.logger.info(
@@ -1450,15 +1480,23 @@ class DayTradingBot:
             f"daily 캐시={cached_count}/{len(candidates)}"
         )
 
-    def _load_macd_cross_daily_batch(self, stock_codes, today_yyyymmdd: str, strategy) -> int:
+    def _load_macd_cross_daily_batch(
+        self,
+        stock_codes,
+        today_yyyymmdd: str,
+        strategy,
+        paper_strategy=None,
+    ) -> int:
         """macd_cross 일괄 daily history 로드 + 캐시 주입 (option B: 단일 connection).
 
         Args:
             stock_codes: 종목 코드 리스트.
             today_yyyymmdd: 오늘 (YYYYMMDD). daily_prices 조회 상한 기준.
-            strategy: MacdCrossStrategy 인스턴스.
+            strategy: 라이브 MacdCrossStrategy 인스턴스 (필수).
+            paper_strategy: 페이퍼 MacdCrossStrategy 인스턴스 (옵션, macd_cross_alt 등).
+                동일 daily history 를 paper 인스턴스에도 주입한다.
         Returns:
-            성공 캐시된 종목 수.
+            성공 캐시된 종목 수 (라이브 기준).
         """
         import psycopg2
         import pandas as pd
@@ -1503,6 +1541,16 @@ class DayTradingBot:
                     strategy.set_daily_history(
                         code, df, today_yyyymmdd, prev_trading_value=prev_tv
                     )
+                    # 신규 paper alt: 동일 daily history → paper 인스턴스에도 주입
+                    if paper_strategy is not None:
+                        try:
+                            paper_strategy.set_daily_history(
+                                code, df, today_yyyymmdd, prev_trading_value=prev_tv
+                            )
+                        except Exception as pe:
+                            self.logger.debug(
+                                f"[paper.macd_cross_alt] daily prep {code}: {pe}"
+                            )
                     cached += 1
                 except Exception as e:
                     try:

--- a/main.py
+++ b/main.py
@@ -1846,12 +1846,13 @@ class DayTradingBot:
             True if 모든 만료 BUY 가 처리됨 (또는 처리할 BUY 없음).
             False if 미관리 종목/가격 미수집 등 transient 상태로 재시도 필요.
 
-        Note: 현재 live/paper exit task 는 label='macd_cross' 하드코딩 상태.
-        paper 추가 인스턴스 (macd_cross_alt 등) 통합 시 label/cfg_class 가
-        하위 task 로 전파되어야 함 (후속 task 에서 진행).
+        Paper alt (macd_cross_alt) 통합: virtual 모드 시 label/cfg_class 를
+        paper exit task 에 전파하여 strategy 별 분리 청산.
         """
         if mode == 'virtual':
-            return await self._macd_cross_paper_exit_task()
+            return await self._macd_cross_paper_exit_task(
+                label=label, cfg_class=cfg_class,
+            )
         elif mode == 'real':
             return await self._macd_cross_live_exit_task()
         return True  # off: no-op
@@ -1977,8 +1978,18 @@ class DayTradingBot:
             self.logger.error(f"❌ macd_cross live exit 실패: {e}")
             return False
 
-    async def _macd_cross_paper_exit_task(self) -> bool:
-        """macd_cross 가상 포지션 hold_days=2 만료 청산.
+    async def _macd_cross_paper_exit_task(
+        self,
+        label: str = 'macd_cross',
+        cfg_class=None,
+    ) -> bool:
+        """macd_cross 가상 포지션 hold_days 만료 청산. label 별 분리.
+
+        Args:
+            label: 'macd_cross' (live paper) / 'macd_cross_alt' (16/32 paper).
+                strategy 컬럼 필터 + save_virtual_sell strategy 인자.
+            cfg_class: StrategySettings.MacdCross 또는 MacdCrossAlt.
+                None 이면 MacdCross (backwards-compat).
 
         Fix B (2026-04-26): 청산 시점을 D2 장 시작 직후 (~09:01~30) 로 이동 — backtest
         의 exit_signal 이 D2 첫 분봉에서 fire 하는 것과 동등. EOD (15:00) 후에도
@@ -2000,15 +2011,19 @@ class DayTradingBot:
                 SELL_COMMISSION, SLIPPAGE_ONE_WAY, ExecutionModel,
             )
 
-            cfg = StrategySettings.MacdCross
+            cfg = cfg_class if cfg_class is not None else StrategySettings.MacdCross
             df = self.db_manager.get_virtual_open_positions()
             if df is None or df.empty:
                 return True
-            df_mc = df[df['strategy'] == 'macd_cross']
+            df_mc = df[df['strategy'] == label]
             if df_mc.empty:
                 return True
 
-            strategy = self.decision_engine.macd_cross_strategy
+            # paper alt 는 paper_macd_cross_strategy, live paper 는 decision_engine 인스턴스 사용
+            if label == 'macd_cross_alt':
+                strategy = getattr(self, 'paper_macd_cross_strategy', None)
+            else:
+                strategy = self.decision_engine.macd_cross_strategy
             today = now_kst().date()
             for _, row in df_mc.iterrows():
                 buy_time = row['buy_time']
@@ -2028,7 +2043,7 @@ class DayTradingBot:
                 # 현재가 (intraday_manager 캐시 — 09:01~30 morning 트리거 시점에 활성)
                 price_info = self.intraday_manager.get_cached_current_price(stock_code)
                 if not price_info:
-                    self.logger.warning(f"[macd_cross.exit] {stock_code} 가격 없음 → skip")
+                    self.logger.warning(f"[{label}.exit] {stock_code} 가격 없음 → skip")
                     pending_skip = True
                     continue
                 current_price = float(price_info.get('current_price', 0))
@@ -2044,7 +2059,7 @@ class DayTradingBot:
                     current_price, prev_close, side="sell"
                 ):
                     self.logger.debug(
-                        f"[macd_cross.exit] {stock_code} 하한가 buffer 위반 → skip (다음 사이클 재시도)"
+                        f"[{label}.exit] {stock_code} 하한가 buffer 위반 → skip (다음 사이클 재시도)"
                     )
                     pending_skip = True
                     continue
@@ -2060,22 +2075,22 @@ class DayTradingBot:
                     stock_name=stock_name,
                     price=sell_price_effective,
                     quantity=quantity,
-                    strategy='macd_cross',
+                    strategy=label,
                     reason=f"hold_limit_days={days_held}",
                     buy_record_id=buy_record_id,
                 )
                 if ok:
                     self.logger.info(
-                        f"👻 [macd_cross] 가상 청산: {stock_code} {quantity}주 "
+                        f"👻 [{label}] 가상 청산: {stock_code} {quantity}주 "
                         f"@{sell_price_effective:,.0f} (mid={current_price:,.0f}, hold {days_held}d)"
                     )
                 else:
                     self.logger.warning(
-                        f"⚠️ [macd_cross] 가상 청산 DB 저장 실패: {stock_code}"
+                        f"⚠️ [{label}] 가상 청산 DB 저장 실패: {stock_code}"
                     )
             return not pending_skip
         except Exception as e:
-            self.logger.error(f"❌ macd_cross paper exit 실패: {e}")
+            self.logger.error(f"❌ {label} paper exit 실패: {e}")
             return False
 
     async def _build_macd_cross_kpi_section(self, label: str, virtual_capital: float):

--- a/main.py
+++ b/main.py
@@ -1765,8 +1765,44 @@ class DayTradingBot:
         except Exception as e:
             self.logger.error(f"❌ 장마감 일괄청산 오류: {e}")
     
+    async def _macd_cross_exit_instance(
+        self,
+        *,
+        label: str,
+        cfg_class,
+        mode: str,
+    ) -> bool:
+        """단일 macd_cross 인스턴스 청산 (D+2 hold_limit_days 만료).
+
+        Args:
+            label: 'macd_cross' / 'macd_cross_alt' — 로그/DB strategy 컬럼 값.
+            cfg_class: StrategySettings.MacdCross 또는 MacdCrossAlt.
+            mode: 'real' / 'virtual' / 'off'.
+
+        모드별 분기:
+        - 'virtual': `_macd_cross_paper_exit_task` (virtual_trading_records)
+        - 'real'   : `_macd_cross_live_exit_task` (real_trading_records + KIS 시장가)
+        - 'off'    : no-op
+
+        Returns:
+            True if 모든 만료 BUY 가 처리됨 (또는 처리할 BUY 없음).
+            False if 미관리 종목/가격 미수집 등 transient 상태로 재시도 필요.
+
+        Note: 현재 live/paper exit task 는 label='macd_cross' 하드코딩 상태.
+        paper 추가 인스턴스 (macd_cross_alt 등) 통합 시 label/cfg_class 가
+        하위 task 로 전파되어야 함 (후속 task 에서 진행).
+        """
+        if mode == 'virtual':
+            return await self._macd_cross_paper_exit_task()
+        elif mode == 'real':
+            return await self._macd_cross_live_exit_task()
+        return True  # off: no-op
+
     async def _macd_cross_exit_dispatcher(self) -> bool:
         """macd_cross 청산 dispatcher — virtual/real 모드 분기.
+
+        instance helper (`_macd_cross_exit_instance`) 로 위임. paper 추가
+        인스턴스 (16/32 등) 도 동일 helper 를 다른 cfg/label/mode 로 호출 가능.
 
         모드 매트릭스 (`_macd_cross_mode`):
           - 'virtual': `_macd_cross_paper_exit_task` (virtual_trading_records)
@@ -1782,12 +1818,13 @@ class DayTradingBot:
         if self._apply_holiday_guard(now_kst(), "청산"):
             return True  # 가드 set 가능 — off 모드와 동일 의미
 
+        from config.strategy_settings import StrategySettings
         mode = self._macd_cross_mode()
-        if mode == 'virtual':
-            return await self._macd_cross_paper_exit_task()
-        elif mode == 'real':
-            return await self._macd_cross_live_exit_task()
-        return True  # off: no-op, 가드 set 가능
+        return await self._macd_cross_exit_instance(
+            label='macd_cross',
+            cfg_class=StrategySettings.MacdCross,
+            mode=mode,
+        )
 
     async def _macd_cross_live_exit_task(self) -> bool:
         """macd_cross 실거래 포지션 hold_days=2 만료 시장가 청산.

--- a/main.py
+++ b/main.py
@@ -640,21 +640,26 @@ class DayTradingBot:
             self._holiday_logged_date = dt.date()
         return True
 
-    def _has_macd_cross_buy_today(self, stock_code: str) -> bool:
-        """오늘 macd_cross 로 이미 진입했는지. DB 오류 시 보수적으로 True (차단)."""
+    def _has_macd_cross_paper_buy_today(self, stock_code: str, label: str = 'macd_cross') -> bool:
+        """오늘 paper macd_cross (label 별) 로 이미 진입했는지. DB 오류 시 보수적으로 True (차단)."""
         try:
             today = now_kst().strftime('%Y-%m-%d')
             row = self.db_manager._fetchone(
                 """SELECT COUNT(*) FROM virtual_trading_records
                    WHERE stock_code=%s AND action='BUY'
-                     AND strategy='macd_cross'
+                     AND strategy=%s
                      AND DATE(timestamp) = %s""",
-                (stock_code, today),
+                (stock_code, label, today),
             )
             return (row[0] if row else 0) > 0
         except Exception as e:
-            self.logger.warning(f"_has_macd_cross_buy_today DB 오류 → 보수적 차단: {e}")
+            self.logger.warning(f"_has_macd_cross_paper_buy_today DB 오류 → 보수적 차단: {e}")
             return True
+
+    # Backwards-compat alias (기존 호출자 호환)
+    def _has_macd_cross_buy_today(self, stock_code: str) -> bool:
+        """Deprecated: _has_macd_cross_paper_buy_today(code, 'macd_cross') 사용."""
+        return self._has_macd_cross_paper_buy_today(stock_code, 'macd_cross')
 
     def _count_today_macd_cross_real_buys(self) -> int:
         """오늘 macd_cross 실거래 BUY 건수 (real_trading_records 기준)."""
@@ -853,35 +858,47 @@ class DayTradingBot:
             return 'virtual'
         return 'off'
 
-    async def _evaluate_macd_cross_window(self, current_time):
-        """macd_cross 진입 평가 (14:31~15:00).
+    async def _evaluate_macd_cross_instance(
+        self,
+        current_time,
+        *,
+        strategy,
+        cfg_class,
+        label: str,
+        mode: str,
+    ):
+        """단일 macd_cross 인스턴스 진입 평가.
 
-        모드별 분기 (`_macd_cross_mode`):
+        Args:
+            current_time: 평가 시점 datetime (KST).
+            strategy: MacdCrossStrategy 인스턴스 (cached universe 보유).
+            cfg_class: StrategySettings.MacdCross 또는 MacdCrossAlt.
+            label: 'macd_cross' / 'macd_cross_alt' — 로그/DB strategy 컬럼 값.
+            mode: 'real' / 'virtual' / 'off'.
+
+        모드별 분기:
         - 'virtual': db_manager.save_virtual_buy 직접 호출 (백테스트 마찰 적용, VTM 우회)
         - 'real'   : decision_engine.execute_real_buy 호출 (KIS 시장가 주문)
         - 'off'    : 즉시 return
 
         공통:
-        - decision_engine.macd_cross_strategy 의 캐시된 universe 만 평가
-        - 시그널 hit 시점은 14:31:00+ (백테스트 next_bar_open 정렬)
+        - 전달된 strategy 의 캐시된 universe 만 평가
+        - 시그널 hit 시점은 ENTRY_HHMM_MIN+ (백테스트 next_bar_open 정렬)
         - 백테스트 가드 적용: 가격제한 buffer + 거래량 feasibility (실거래에도 동일 적용)
         """
-        from config.strategy_settings import StrategySettings
         from backtests.common.execution_model import (
             BUY_COMMISSION, SLIPPAGE_ONE_WAY, ExecutionModel,
         )
 
-        mode = self._macd_cross_mode()
-        if mode == 'off' or self.decision_engine.macd_cross_strategy is None:
+        if mode == 'off' or strategy is None:
             return
         is_virtual = (mode == 'virtual')
 
         if self._apply_holiday_guard(current_time, "매수"):
             return
 
-        cfg_mc = StrategySettings.MacdCross
         hhmm = current_time.hour * 100 + current_time.minute
-        if not (cfg_mc.ENTRY_HHMM_MIN <= hhmm <= cfg_mc.ENTRY_HHMM_MAX):
+        if not (cfg_class.ENTRY_HHMM_MIN <= hhmm <= cfg_class.ENTRY_HHMM_MAX):
             return
 
         # 🚨 실거래 모드 한정: 전일 -3% 서킷브레이커 inherit (자본 보호 absolute)
@@ -889,23 +906,22 @@ class DayTradingBot:
         if not is_virtual and self._macd_cross_circuit_breaker_blocks(current_time):
             return
 
-        strategy = self.decision_engine.macd_cross_strategy
         universe_codes = list(strategy._cache.keys()) if hasattr(strategy, '_cache') else []
         if not universe_codes:
             return
 
         # 일일 진입 한도 체크 (모드별 카운팅)
         def _today_buy_count() -> int:
-            return (self._count_open_paper_positions('macd_cross')
+            return (self._count_open_paper_positions(label)
                     if is_virtual
                     else self._count_today_macd_cross_real_buys())
 
         def _has_buy_today(code: str) -> bool:
-            return (self._has_macd_cross_buy_today(code)
+            return (self._has_macd_cross_paper_buy_today(code, label)
                     if is_virtual
                     else self._has_macd_cross_real_buy_today(code))
 
-        if _today_buy_count() >= cfg_mc.MAX_DAILY_POSITIONS:
+        if _today_buy_count() >= cfg_class.MAX_DAILY_POSITIONS:
             return
 
         for stock_code in universe_codes:
@@ -914,7 +930,7 @@ class DayTradingBot:
                     continue
                 if _has_buy_today(stock_code):
                     continue
-                if _today_buy_count() >= cfg_mc.MAX_DAILY_POSITIONS:
+                if _today_buy_count() >= cfg_class.MAX_DAILY_POSITIONS:
                     break
 
                 price_info = self.intraday_manager.get_cached_current_price(stock_code)
@@ -930,7 +946,7 @@ class DayTradingBot:
                     current_price, prev_close, side="buy"
                 ):
                     self.logger.debug(
-                        f"[macd_cross] {stock_code} 상한가 buffer 위반 → skip"
+                        f"[{label}] {stock_code} 상한가 buffer 위반 → skip"
                     )
                     continue
 
@@ -942,11 +958,11 @@ class DayTradingBot:
                     # 백테스트 마찰: 슬리피지 + 매수 수수료
                     buy_fill = current_price * (1 + SLIPPAGE_ONE_WAY)
                     buy_price_effective = buy_fill * (1 + BUY_COMMISSION)
-                    budget = cfg_mc.VIRTUAL_CAPITAL * cfg_mc.BUY_BUDGET_RATIO
+                    budget = cfg_class.VIRTUAL_CAPITAL * cfg_class.BUY_BUDGET_RATIO
                     quantity = int(budget / buy_price_effective)
                     if quantity <= 0:
                         self.logger.debug(
-                            f"[macd_cross] {stock_code} buy_price {buy_price_effective:,.0f} > "
+                            f"[{label}] {stock_code} buy_price {buy_price_effective:,.0f} > "
                             f"budget {budget:,.0f} → quantity 0 → skip"
                         )
                         continue
@@ -955,7 +971,7 @@ class DayTradingBot:
                         order_value, prev_trading_value
                     ):
                         self.logger.debug(
-                            f"[macd_cross] {stock_code} 거래량 한도 위반 "
+                            f"[{label}] {stock_code} 거래량 한도 위반 "
                             f"(주문 {order_value:,.0f} > {prev_trading_value*0.02:,.0f}) → skip"
                         )
                         continue
@@ -964,17 +980,17 @@ class DayTradingBot:
                         stock_name=stock_name,
                         price=buy_price_effective,
                         quantity=quantity,
-                        strategy='macd_cross',
-                        reason=f"macd_cross_signal_hhmm{hhmm}",
+                        strategy=label,
+                        reason=f"{label}_signal_hhmm{hhmm}",
                     )
                     if buy_record_id:
                         self.logger.info(
-                            f"👻 [macd_cross] 가상 매수: {stock_code} {quantity}주 "
+                            f"👻 [{label}] 가상 매수: {stock_code} {quantity}주 "
                             f"@{buy_price_effective:,.0f} (mid={current_price:,.0f}, id={buy_record_id})"
                         )
                     else:
                         self.logger.warning(
-                            f"⚠️ [macd_cross] 가상 매수 실패: {stock_code} {quantity}주"
+                            f"⚠️ [{label}] 가상 매수 실패: {stock_code} {quantity}주"
                         )
                 else:
                     # === Real path (실 계좌 시장가 주문) ===
@@ -982,18 +998,18 @@ class DayTradingBot:
                     # MAX_DAILY_POSITIONS=5 의 남은 슬롯 수 = 5 - 오늘 진입 건수
                     # 첫 진입: 6.43M / 5 = 1.286M, 두번째: 5.14M / 4 = 1.285M ...
                     fund_status = self.fund_manager.get_status()
-                    remaining_slots = cfg_mc.MAX_DAILY_POSITIONS - _today_buy_count()
+                    remaining_slots = cfg_class.MAX_DAILY_POSITIONS - _today_buy_count()
                     if remaining_slots <= 0:
                         break
                     budget = fund_status['available_funds'] / remaining_slots
                     # 안전 캡: 단일 포지션 최대 = total × BUY_BUDGET_RATIO
-                    budget = min(budget, fund_status['total_funds'] * cfg_mc.BUY_BUDGET_RATIO)
+                    budget = min(budget, fund_status['total_funds'] * cfg_class.BUY_BUDGET_RATIO)
                     if budget <= 0 or current_price <= 0:
                         continue
                     quantity = int(budget / current_price)
                     if quantity <= 0:
                         self.logger.debug(
-                            f"[macd_cross] {stock_code} budget {budget:,.0f} / price "
+                            f"[{label}] {stock_code} budget {budget:,.0f} / price "
                             f"{current_price:,.0f} → quantity 0 → skip"
                         )
                         continue
@@ -1003,35 +1019,53 @@ class DayTradingBot:
                         order_value, prev_trading_value
                     ):
                         self.logger.debug(
-                            f"[macd_cross] {stock_code} 거래량 한도 위반 "
+                            f"[{label}] {stock_code} 거래량 한도 위반 "
                             f"(주문 {order_value:,.0f} > {prev_trading_value*0.02:,.0f}) → skip"
                         )
                         continue
                     if ts is None:
                         self.logger.warning(
-                            f"⚠️ [macd_cross] {stock_code} trading_stock 미등록 → skip"
+                            f"⚠️ [{label}] {stock_code} trading_stock 미등록 → skip"
                         )
                         continue
                     ok = await self.decision_engine.execute_real_buy(
                         ts,
-                        f"macd_cross_signal_hhmm{hhmm}",
+                        f"{label}_signal_hhmm{hhmm}",
                         current_price,
                         quantity,
                         candle_time=current_time,
-                        strategy_tag='macd_cross',
+                        strategy_tag=label,
                         market=True,
                     )
                     if ok:
                         self.logger.info(
-                            f"🔥 [macd_cross] 실 매수 주문: {stock_code} {quantity}주 "
+                            f"🔥 [{label}] 실 매수 주문: {stock_code} {quantity}주 "
                             f"@~{current_price:,.0f} (시장가, 예산 {budget:,.0f})"
                         )
                     else:
                         self.logger.warning(
-                            f"⚠️ [macd_cross] 실 매수 주문 실패: {stock_code} {quantity}주"
+                            f"⚠️ [{label}] 실 매수 주문 실패: {stock_code} {quantity}주"
                         )
             except Exception as e:
-                self.logger.error(f"❌ [macd_cross] {stock_code} 평가 오류: {e}")
+                self.logger.error(f"❌ [{label}] {stock_code} 평가 오류: {e}")
+
+    async def _evaluate_macd_cross_window(self, current_time):
+        """macd_cross 라이브 진입 평가 (14:31~15:00). 기존 단일 인스턴스 경로 유지.
+
+        instance helper (`_evaluate_macd_cross_instance`) 로 위임. paper 추가
+        인스턴스 (16/32 등) 도 동일 helper 를 다른 strategy/cfg/label/mode 로
+        호출 가능.
+        """
+        from config.strategy_settings import StrategySettings
+        mode = self._macd_cross_mode()
+        strategy = self.decision_engine.macd_cross_strategy if self.decision_engine else None
+        await self._evaluate_macd_cross_instance(
+            current_time,
+            strategy=strategy,
+            cfg_class=StrategySettings.MacdCross,
+            label='macd_cross',
+            mode=mode,
+        )
 
     async def _analyze_buy_decision(self, trading_stock, available_funds: float = None):
         """매수 판단 분석 (완성된 1분봉 기준)

--- a/main.py
+++ b/main.py
@@ -1093,6 +1093,16 @@ class DayTradingBot:
             label='macd_cross',
             mode=mode,
         )
+        # 신규: paper 16/32 alt 평가 — 라이브와 분리, 항상 'virtual' mode
+        if (StrategySettings.PAPER_STRATEGY == 'macd_cross_alt'
+                and getattr(self, 'paper_macd_cross_strategy', None) is not None):
+            await self._evaluate_macd_cross_instance(
+                current_time,
+                strategy=self.paper_macd_cross_strategy,
+                cfg_class=StrategySettings.MacdCrossAlt,
+                label='macd_cross_alt',
+                mode='virtual',
+            )
 
     async def _analyze_buy_decision(self, trading_stock, available_funds: float = None):
         """매수 판단 분석 (완성된 1분봉 기준)

--- a/main.py
+++ b/main.py
@@ -1878,11 +1878,23 @@ class DayTradingBot:
 
         from config.strategy_settings import StrategySettings
         mode = self._macd_cross_mode()
-        return await self._macd_cross_exit_instance(
+        live_result = await self._macd_cross_exit_instance(
             label='macd_cross',
             cfg_class=StrategySettings.MacdCross,
             mode=mode,
         )
+        # 신규: paper 16/32 alt 청산 — 라이브 결과와 별도, 항상 'virtual' mode
+        if (StrategySettings.PAPER_STRATEGY == 'macd_cross_alt'
+                and getattr(self, 'paper_macd_cross_strategy', None) is not None):
+            try:
+                await self._macd_cross_exit_instance(
+                    label='macd_cross_alt',
+                    cfg_class=StrategySettings.MacdCrossAlt,
+                    mode='virtual',
+                )
+            except Exception as e:
+                self.logger.warning(f"[paper.macd_cross_alt] 청산 오류: {e}")
+        return live_result
 
     async def _macd_cross_live_exit_task(self) -> bool:
         """macd_cross 실거래 포지션 hold_days=2 만료 시장가 청산.

--- a/main.py
+++ b/main.py
@@ -453,9 +453,9 @@ class DayTradingBot:
                             self._check_macd_cross_kill_switch_thresholds()
                         except Exception as e:
                             self.logger.error(f"❌ macd_cross 킬 스위치 체크 실패: {e}")
-                        # macd_cross paper 일일 보고 + safety stop 체크 (Task 11)
+                        # macd_cross / macd_cross_alt paper 일일 보고 + safety stop 체크
                         try:
-                            if StrategySettings.PAPER_STRATEGY == 'macd_cross':
+                            if StrategySettings.PAPER_STRATEGY in ('macd_cross', 'macd_cross_alt'):
                                 await self._macd_cross_paper_daily_report()
                         except Exception as e:
                             self.logger.error(f"❌ macd_cross 일일 보고 트리거 실패: {e}")
@@ -2078,23 +2078,25 @@ class DayTradingBot:
             self.logger.error(f"❌ macd_cross paper exit 실패: {e}")
             return False
 
-    async def _macd_cross_paper_daily_report(self):
-        """macd_cross 페이퍼 일일 KPI 집계 + 텔레그램 알림 + safety stop 체크.
+    async def _build_macd_cross_kpi_section(self, label: str, virtual_capital: float):
+        """단일 paper 전략의 KPI 섹션 텍스트 + safety_stop 플래그 반환.
 
-        EOD 직후 (paper exit 끝난 다음) 1회 호출. KPI 계산은 KPI 모듈
-        (core.strategies.macd_cross_kpi.MacdCrossKpi) 에 위임.
+        Args:
+            label: 'macd_cross' / 'macd_cross_alt' — virtual_trading_records.strategy 필터 값.
+            virtual_capital: KPI 계산 기준 자본 (cfg.VIRTUAL_CAPITAL).
+
+        Returns:
+            (section_text, safety_stop) 튜플. 실패 시 (None, False).
         """
         try:
-            from config.strategy_settings import StrategySettings
             from core.strategies.macd_cross_kpi import MacdCrossKpi
 
-            cfg = StrategySettings.MacdCross
-            kpi = MacdCrossKpi(virtual_capital=cfg.VIRTUAL_CAPITAL)
+            kpi = MacdCrossKpi(virtual_capital=virtual_capital)
 
             loop = asyncio.get_running_loop()
             df = await loop.run_in_executor(
                 None,
-                lambda: self.db_manager.get_virtual_paired_trades(strategy='macd_cross'),
+                lambda: self.db_manager.get_virtual_paired_trades(strategy=label),
             )
 
             metrics = kpi.compute(df) if df is not None else kpi.compute(pd.DataFrame())
@@ -2105,7 +2107,7 @@ class DayTradingBot:
             progress_pct = (metrics['trade_count'] / target_trades * 100) if target_trades else 0
 
             lines = [
-                "📊 macd_cross 페이퍼 일일 보고",
+                f"📊 {label} 페이퍼 일일 보고",
                 f"진행: {metrics['trade_count']} trades / {progress_pct:.0f}% (목표 {target_trades})",
                 f"return: {metrics['return']*100:+.2f}% | MDD: {metrics['mdd']*100:+.2f}% | win: {metrics['win_rate']*100:.1f}%",
                 f"Calmar: {metrics['calmar']:.1f} | top1: {metrics['top1_share']*100:.1f}% | streak: {metrics['max_consec_losses']}",
@@ -2123,9 +2125,57 @@ class DayTradingBot:
                     val_str = str(g['value'])
                 lines.append(f"  {mark} {g['label']} → {val_str}")
             if safety:
-                lines.append("⚠️ SAFETY STOP 충족 — paper 즉시 중단 권고. PAPER_STRATEGY=None 으로 설정.")
+                lines.append(
+                    f"⚠️ {label} SAFETY STOP 충족 — paper 즉시 중단 권고. "
+                    "PAPER_STRATEGY=None 으로 설정."
+                )
+            return "\n".join(lines), safety
+        except Exception as e:
+            self.logger.error(f"❌ {label} KPI 섹션 생성 실패: {e}")
+            return None, False
 
-            msg = "\n".join(lines)
+    async def _macd_cross_paper_daily_report(self):
+        """macd_cross / macd_cross_alt 페이퍼 일일 KPI 집계 + 텔레그램 알림 + safety stop.
+
+        EOD 직후 (paper exit 끝난 다음) 1회 호출. PAPER_STRATEGY 활성 전략별로
+        섹션을 생성해 dual KPI 출력. KPI 계산은 KPI 모듈
+        (core.strategies.macd_cross_kpi.MacdCrossKpi) 에 위임.
+
+        섹션 매트릭스:
+          - PAPER_STRATEGY='macd_cross'      → macd_cross 섹션
+          - PAPER_STRATEGY='macd_cross_alt'  → macd_cross_alt 섹션
+          - 활성 paper 가 둘 다이면 두 섹션 모두 출력 (현재는 단일 활성만 가능)
+        """
+        try:
+            from config.strategy_settings import StrategySettings
+
+            sections = []
+            any_safety = False
+
+            # 섹션 1: macd_cross (paper) — 기존 경로
+            if StrategySettings.PAPER_STRATEGY == 'macd_cross':
+                section, safety = await self._build_macd_cross_kpi_section(
+                    label='macd_cross',
+                    virtual_capital=StrategySettings.MacdCross.VIRTUAL_CAPITAL,
+                )
+                if section:
+                    sections.append(section)
+                    any_safety = any_safety or safety
+
+            # 섹션 2: macd_cross_alt (paper) — 신규 (16/32 검증)
+            if StrategySettings.PAPER_STRATEGY == 'macd_cross_alt':
+                section, safety = await self._build_macd_cross_kpi_section(
+                    label='macd_cross_alt',
+                    virtual_capital=StrategySettings.MacdCrossAlt.VIRTUAL_CAPITAL,
+                )
+                if section:
+                    sections.append(section)
+                    any_safety = any_safety or safety
+
+            if not sections:
+                return
+
+            msg = "\n\n".join(sections)
             if self.telegram is not None:
                 try:
                     await self.telegram.notify_system_status(msg)

--- a/tests/integration/test_macd_cross_alt_paper_flow.py
+++ b/tests/integration/test_macd_cross_alt_paper_flow.py
@@ -1,0 +1,76 @@
+"""macd_cross_alt (16/32) paper flow E2E.
+
+라이브 14/34 와 paper 16/32 가 같은 봇 인스턴스에서 동시 동작 — paper 만
+가상매매로 routing 되는지, KPI 집계가 strategy='macd_cross_alt' 필터로
+분리되는지 검증.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from core.strategies.macd_cross_kpi import MacdCrossKpi
+from core.strategies.macd_cross_strategy import MacdCrossStrategy
+
+
+@pytest.fixture
+def alt_strategy():
+    return MacdCrossStrategy(
+        fast=16, slow=32, signal=12, entry_hhmm_min=1431,
+        label='macd_cross_alt',
+    )
+
+
+def test_alt_strategy_label_propagates_to_logging(alt_strategy):
+    """label 'macd_cross_alt' 가 인스턴스에 보존."""
+    assert alt_strategy.label == 'macd_cross_alt'
+
+
+def test_alt_signal_independent_from_live():
+    """동일 daily history 입력 시 14/34 와 16/32 의 prev_hist 가 다름."""
+    import pandas as pd
+    import numpy as np
+
+    np.random.seed(42)
+    n = 60
+    df = pd.DataFrame({
+        "trade_date": [f"202509{i:02d}" for i in range(1, n + 1)],
+        "close": 1000 + np.cumsum(np.random.randn(n) * 5),
+    })
+    live = MacdCrossStrategy(fast=14, slow=34, signal=12, label='macd_cross')
+    paper = MacdCrossStrategy(fast=16, slow=32, signal=12, label='macd_cross_alt')
+
+    live.set_daily_history("000001", df, "20251102")
+    paper.set_daily_history("000001", df, "20251102")
+
+    live_hist = live.get_cached_hist("000001")
+    paper_hist = paper.get_cached_hist("000001")
+
+    # 다른 fast/slow 로 다른 hist 값 → cache 분리 검증
+    assert live_hist != paper_hist
+
+
+def test_kpi_filter_by_strategy_label(monkeypatch):
+    """KPI 가 'macd_cross_alt' strategy filter 시 alt rows 만 집계."""
+    import pandas as pd
+
+    df_alt_only = pd.DataFrame({
+        "buy_time": pd.to_datetime(["2026-05-12 14:31", "2026-05-13 14:31"]),
+        "sell_time": pd.to_datetime(["2026-05-14 09:01", "2026-05-15 09:01"]),
+        "pnl": [50000.0, -30000.0],
+    })
+    kpi = MacdCrossKpi(virtual_capital=10_000_000)
+    metrics = kpi.compute(df_alt_only)
+    assert metrics["trade_count"] == 2
+    assert metrics["return"] == pytest.approx((50000 - 30000) / 10_000_000)
+    gates = kpi.evaluate_gates(metrics)
+    # 표본 적어 calmar/return 등 통과/탈락은 의미 없음 — 게이트 평가 동작만 확인
+    assert "all_pass" in gates
+
+
+@pytest.mark.skip(reason="Requires KIS API mock + DB fixture — run manually after Task 8")
+def test_full_flow_signal_to_kpi():
+    """E2E: signal hit → save_virtual_buy(strategy='macd_cross_alt') → D+2 청산
+    → fetch_virtual_trades('macd_cross_alt') → KPI 집계.
+
+    DB fixture + KIS mock 준비 후 활성화.
+    """
+    pass

--- a/tests/integration/test_macd_cross_holiday_guard.py
+++ b/tests/integration/test_macd_cross_holiday_guard.py
@@ -104,7 +104,8 @@ async def test_evaluate_macd_cross_window_skips_holiday():
     bot.decision_engine.execute_real_buy = AsyncMock()
     bot.db_manager = MagicMock()
     bot._macd_cross_mode = MagicMock(return_value='real')
-    _bind(bot, '_evaluate_macd_cross_window', '_apply_holiday_guard')
+    _bind(bot, '_evaluate_macd_cross_window', '_evaluate_macd_cross_instance',
+          '_apply_holiday_guard')
 
     holiday_dt = KST.localize(datetime(2026, 5, 5, 14, 31))
 

--- a/tests/integration/test_macd_cross_premarket_sync.py
+++ b/tests/integration/test_macd_cross_premarket_sync.py
@@ -217,7 +217,8 @@ async def test_dispatcher_returns_true_when_mode_off():
     """mode=off → True (no-op, 가드 set OK)."""
     bot = _FakeBot()
     bot._macd_cross_mode = MagicMock(return_value='off')
-    _bind(bot, '_macd_cross_exit_dispatcher', '_apply_holiday_guard')
+    _bind(bot, '_macd_cross_exit_dispatcher', '_macd_cross_exit_instance',
+          '_apply_holiday_guard')
 
     with patch('main.now_kst', return_value=_WEEKDAY_DT):
         result = await bot._macd_cross_exit_dispatcher()
@@ -232,7 +233,8 @@ async def test_dispatcher_passes_through_live_bool():
     bot._macd_cross_mode = MagicMock(return_value='real')
     bot._macd_cross_live_exit_task = AsyncMock(return_value=False)
     bot._macd_cross_paper_exit_task = AsyncMock(return_value=True)
-    _bind(bot, '_macd_cross_exit_dispatcher', '_apply_holiday_guard')
+    _bind(bot, '_macd_cross_exit_dispatcher', '_macd_cross_exit_instance',
+          '_apply_holiday_guard')
 
     with patch('main.now_kst', return_value=_WEEKDAY_DT):
         result = await bot._macd_cross_exit_dispatcher()
@@ -249,7 +251,8 @@ async def test_dispatcher_passes_through_paper_bool():
     bot._macd_cross_mode = MagicMock(return_value='virtual')
     bot._macd_cross_live_exit_task = AsyncMock(return_value=True)
     bot._macd_cross_paper_exit_task = AsyncMock(return_value=False)
-    _bind(bot, '_macd_cross_exit_dispatcher', '_apply_holiday_guard')
+    _bind(bot, '_macd_cross_exit_dispatcher', '_macd_cross_exit_instance',
+          '_apply_holiday_guard')
 
     with patch('main.now_kst', return_value=_WEEKDAY_DT):
         result = await bot._macd_cross_exit_dispatcher()

--- a/tests/strategies/test_macd_cross_alt_settings.py
+++ b/tests/strategies/test_macd_cross_alt_settings.py
@@ -1,0 +1,58 @@
+"""MacdCrossAlt 설정 + validate_settings 가드 검증."""
+import pytest
+
+from config.strategy_settings import StrategySettings, validate_settings
+
+
+def test_macd_cross_alt_class_has_required_attrs():
+    """16/32 paper 파라미터 존재 + 값 정확."""
+    cfg = StrategySettings.MacdCrossAlt
+    assert cfg.FAST_PERIOD == 16
+    assert cfg.SLOW_PERIOD == 32
+    assert cfg.SIGNAL_PERIOD == 12
+    assert cfg.ENTRY_HHMM_MIN == 1431
+    assert cfg.ENTRY_HHMM_MAX == 1500
+    assert cfg.HOLD_DAYS == 2
+    assert cfg.VIRTUAL_CAPITAL == 10_000_000
+    assert cfg.BUY_BUDGET_RATIO == 0.20
+    assert cfg.MAX_DAILY_POSITIONS == 5
+    assert cfg.UNIVERSE_TOP_N == 30
+    assert cfg.VIRTUAL_ONLY is True
+
+
+def test_valid_paper_strategies_includes_macd_cross_alt():
+    """'macd_cross_alt' 가 valid list 에 있어야 validate_settings 통과."""
+    original = StrategySettings.PAPER_STRATEGY
+    try:
+        StrategySettings.PAPER_STRATEGY = 'macd_cross_alt'
+        assert validate_settings() is True
+    finally:
+        StrategySettings.PAPER_STRATEGY = original
+
+
+def test_universe_top_n_must_match_macd_cross():
+    """MacdCrossAlt.UNIVERSE_TOP_N != MacdCross.UNIVERSE_TOP_N 시 ValueError."""
+    original_alt = StrategySettings.MacdCrossAlt.UNIVERSE_TOP_N
+    original_paper = StrategySettings.PAPER_STRATEGY
+    try:
+        StrategySettings.MacdCrossAlt.UNIVERSE_TOP_N = 50
+        StrategySettings.PAPER_STRATEGY = 'macd_cross_alt'
+        with pytest.raises(ValueError, match="UNIVERSE_TOP_N"):
+            validate_settings()
+    finally:
+        StrategySettings.MacdCrossAlt.UNIVERSE_TOP_N = original_alt
+        StrategySettings.PAPER_STRATEGY = original_paper
+
+
+def test_entry_hhmm_min_lt_max():
+    """ENTRY_HHMM_MIN >= MAX 시 validate_settings 가 ValueError."""
+    original_min = StrategySettings.MacdCrossAlt.ENTRY_HHMM_MIN
+    original_paper = StrategySettings.PAPER_STRATEGY
+    try:
+        StrategySettings.MacdCrossAlt.ENTRY_HHMM_MIN = 1500
+        StrategySettings.PAPER_STRATEGY = 'macd_cross_alt'
+        with pytest.raises(ValueError, match="ENTRY_HHMM_MIN"):
+            validate_settings()
+    finally:
+        StrategySettings.MacdCrossAlt.ENTRY_HHMM_MIN = original_min
+        StrategySettings.PAPER_STRATEGY = original_paper

--- a/tests/strategies/test_macd_cross_strategy.py
+++ b/tests/strategies/test_macd_cross_strategy.py
@@ -83,3 +83,29 @@ def test_set_daily_history_clears_meta_on_date_change():
     )
     assert s.get_daily_meta("005930") == (None, None)
     assert s.get_daily_meta("000660") != (None, None)
+
+
+def test_macd_cross_strategy_default_label():
+    """label 기본값 = 'macd_cross'."""
+    from core.strategies.macd_cross_strategy import MacdCrossStrategy
+    s = MacdCrossStrategy()
+    assert s.label == 'macd_cross'
+
+
+def test_macd_cross_strategy_custom_label():
+    """label 인자 주입 시 그대로 저장."""
+    from core.strategies.macd_cross_strategy import MacdCrossStrategy
+    s = MacdCrossStrategy(label='macd_cross_alt')
+    assert s.label == 'macd_cross_alt'
+
+
+def test_macd_cross_strategy_alt_params_via_kwargs():
+    """16/32 파라미터 주입 시 정상 보관."""
+    from core.strategies.macd_cross_strategy import MacdCrossStrategy
+    s = MacdCrossStrategy(fast=16, slow=32, signal=12,
+                          entry_hhmm_min=1431, label='macd_cross_alt')
+    assert s.fast == 16
+    assert s.slow == 32
+    assert s.signal == 12
+    assert s.entry_hhmm_min == 1431
+    assert s.label == 'macd_cross_alt'


### PR DESCRIPTION
## Summary

PR #45 의 MV-A 멀티버스 결과를 기반으로 **fast=16/slow=32 paper 검증 인프라** 구축 + 활성화.

- 라이브 14/34 (실거래) **유지** + paper 16/32 (가상) **나란히 운영**
- 4ds-avg calmar 65→128 (+95%) 의 OOS 재현성 검증
- 4주 또는 30 trades 도달 시 6 KPI 게이트 평가 → 통과 시 swap PR

### Spec / Plan
- Spec: `docs/superpowers/specs/2026-05-09-macd-cross-alt-paper-validation-design.md`
- Plan: `docs/superpowers/plans/2026-05-09-macd-cross-alt-paper-validation.md` (10-task TDD)

### 구현 요약 (12 implementation commits)

| Task | Commit | 내용 |
|------|--------|------|
| T1 | 9f65a9dc + 7f683538 | `MacdCrossAlt` 설정 + validate_settings 5 가드 + CANDLE_INTERVAL parity |
| T2 | dafc4ac6 | `MacdCrossStrategy` `label` 파라미터 |
| T3 | fb29aa42 | `_evaluate_macd_cross_window` → instance helper 추출 (regression-safe) |
| T4 | c500cc5b | `_macd_cross_exit_dispatcher` 동일 추출 |
| T5 | d36f8ca4 | `paper_macd_cross_strategy` 인스턴스 + pre_market 캐시 주입 |
| T6 | 32ed21db | paper 진입 평가 분기 추가 |
| T7 | ee07d594 | paper 청산 dispatcher 분기 추가 |
| T8 | 478ccf39 | EOD 텔레그램 dual KPI 섹션 |
| T9 | 980bc56c | paper alt flow E2E test (3 신규 + 1 skip) |
| T10 | a0296f21 | 운영 문서 + `PAPER_STRATEGY='macd_cross_alt'` 활성화 |
| Final review fix | fdd5d984 | `_macd_cross_paper_exit_task` 가 label 인자 받도록 (HIGH bug) |

### 격리 보장
- 자금: real `FundManager` ↔ paper `VirtualFundManager` 완전 분리
- 포지션: real (KIS 계좌) / paper (`virtual_trading_records.strategy='macd_cross_alt'`) 별도
- KPI: 텔레그램 EOD 두 섹션 분리 (`[macd_cross]` real / `[macd_cross_alt]` paper)
- universe: top 30 단일 preload, 두 인스턴스 공유 (validate_settings 강제)

### 안전망
- live 14/34 실거래 경로 변경 0 (helper 추출은 1:1 위임)
- circuit breaker: real-only 적용 보존 (paper 는 G1 백테스트 100% 재현 원칙)
- 즉시 정지: `PAPER_STRATEGY=None` 으로 paper 비활성화 가능
- 중도 안전정지: 누적 -5% 또는 5연패 발동
- DB 스키마 변경 없음 (기존 `virtual_trading_records.strategy` 컬럼 활용)

### Test Plan

- [x] 회귀: **280 passed, 1 skipped** (기존 270 + 신규 11 — 4 settings + 3 strategy + 4 paper_flow)
- [x] `validate_settings()` 통과 (PAPER_STRATEGY='macd_cross_alt' 활성)
- [x] `import main` OK
- [x] Final code review: HIGH 1건 발견 + 즉시 수정 (commit fdd5d984)
- [ ] 봇 재시작 후 첫 영업일 운영 로그 확인 (`grep "macd_cross_alt" logs/trading_YYYYMMDD.log`)
- [ ] 텔레그램 EOD 보고에 두 섹션 출력 확인
- [ ] 4주 또는 30 trades 도달 시 KPI 게이트 평가

🤖 Generated with [Claude Code](https://claude.com/claude-code)