### PR TITLE
fix(macd_cross): 킬스위치 라벨 버그 수정 + KOSDAQ 5일낙폭 레짐필터

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,8 @@ utils/                         # data_cache, korean_time
 | 항목 | 동작 |
 |------|------|
 | 서킷브레이커 | 전일 KOSPI/KOSDAQ -3% → macd_cross 매수 차단 |
-| 킬 스위치 | 누적 -5% 또는 5연속 손실 → ACTIVE_STRATEGY 정지 (디스크 저장) |
+| KOSDAQ 레짐필터 | KOSDAQ(KQ11) 직전 5거래일 -2% 이하 → macd_cross 매수 차단 (실거래, 2026-06-04, fold 검증 PASS) |
+| 킬 스위치 | 누적 -5% 또는 5연속 손실 → ACTIVE_STRATEGY 정지 (디스크 저장). 매도는 매수 strategy(buy_record_id) 기준 집계 |
 | 장마감 청산 | 15:00 보유 종목 시장가 매도 (단, macd_cross D+2 미도달은 보호) |
 | 매수 쿨다운 | 동일 종목 25분 내 재매수 차단 (macd_cross 는 미적용 — 1일 1회 가드) |
 | API Rate Limiting | 60ms 간격, 연속 실패 시 차단 |

--- a/analysis/macd_cross_kosdaq_regime_validate.py
+++ b/analysis/macd_cross_kosdaq_regime_validate.py
@@ -1,0 +1,165 @@
+"""KOSDAQ(KQ11) 기반 macd_cross 레짐필터 풀-fold 검증.
+
+기존 regime_filter_v2 는 KOSPI(KS11) 기준 → 5~6월 KOSDAQ 약세 손실을 못 가림
+(analysis/macd_cross_recent_mv.py 발견). 본 러너는 동일 신호를 KOSDAQ 기준으로
+fold1/2/3 + oos + recent 전체에서 평가해 채택 가능성(강건성)을 판정한다.
+
+판정 기준 (per-signal, vs off baseline, return 기준):
+  - 나쁜장 완화: 음(-)수익 dataset 에서 Δret > 0
+  - 좋은장 미악화: 양(+)수익 dataset 에서 Δret >= -0.5%p (작은 비용 허용)
+"""
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pandas as pd
+
+from backtests.common.engine import BacktestEngine
+from backtests.common.data_loader import load_minute_df, load_daily_df, load_index_df
+from backtests.multiverse.universe import select_top_universe
+from backtests.multiverse.macd_cross_mv_common import (
+    Dataset, build_cell_kpis, _trading_days_count, load_all_datasets,
+)
+from backtests.strategies.macd_cross_regime_filter import MACDCrossRegimeFilterStrategy
+
+BEST = {"fast_period": 14, "slow_period": 34, "signal_period": 12, "entry_hhmm_min": 1430}
+DAILY_START = "20250101"
+RECENT_START, RECENT_END = "20260425", "20260604"
+
+SIGNALS = [
+    {"label": "off",           "enabled": False, "signal_type": "5d_return_drop", "threshold": None},
+    {"label": "5d_drop_-1pct", "enabled": True,  "signal_type": "5d_return_drop", "threshold": -0.01},
+    {"label": "5d_drop_-2pct", "enabled": True,  "signal_type": "5d_return_drop", "threshold": -0.02},
+    {"label": "5d_drop_-3pct", "enabled": True,  "signal_type": "5d_return_drop", "threshold": -0.03},
+    {"label": "20d_neg_-3pct", "enabled": True,  "signal_type": "20d_return_neg", "threshold": -0.03},
+]
+
+
+def _norm_index(code: str, end: str) -> pd.DataFrame:
+    raw = load_index_df(code, DAILY_START, end)
+    return pd.DataFrame({
+        "trade_date": raw["trade_date"].astype(str),
+        "close": raw["close"].astype(float),
+    }).sort_values("trade_date").reset_index(drop=True)
+
+
+def build_recent(universe: List[str], kosdaq_df: pd.DataFrame) -> Dataset:
+    minute_df = load_minute_df(universe, RECENT_START, RECENT_END)
+    daily_df = load_daily_df(universe, DAILY_START, RECENT_END)
+    m_full = {c: minute_df[minute_df["stock_code"] == c].reset_index(drop=True) for c in universe}
+    d_full = {c: daily_df[daily_df["stock_code"] == c].reset_index(drop=True) for c in universe}
+    m_by = {
+        c: m_full[c][(m_full[c]["trade_date"] >= RECENT_START) & (m_full[c]["trade_date"] <= RECENT_END)]
+            .reset_index(drop=True) for c in universe
+    }
+    d_by = {c: d_full[c][d_full[c]["trade_date"] <= RECENT_END].reset_index(drop=True) for c in universe}
+    nonempty = [c for c in universe if len(m_by[c]) > 0]
+    ds = Dataset(
+        name="recent", minute_start=RECENT_START, minute_end=RECENT_END, daily_start=DAILY_START,
+        minute_by_code={c: m_by[c] for c in nonempty}, daily_by_code={c: d_by[c] for c in nonempty},
+        universe=nonempty, kospi_daily_df=kosdaq_df,
+    )
+    return ds
+
+
+def evaluate(strategy, ds: Dataset) -> Dict:
+    eng = BacktestEngine(
+        strategy=strategy, initial_capital=10_000_000, universe=ds.universe,
+        minute_df_by_code=ds.minute_by_code, daily_df_by_code=ds.daily_by_code,
+    )
+    result = eng.run()
+    return build_cell_kpis(
+        equity=result.equity_curve, trades=result.trades,
+        trading_days=_trading_days_count(ds.minute_by_code),
+    )
+
+
+def main():
+    print("[kosdaq-regime] fold1/2/3/oos 로드...")
+    datasets = load_all_datasets()  # fold1/2/3/oos, minute~20260424
+    uni = list(next(iter(datasets.values())).universe)
+    # 전체 universe (fold 별 nonempty 합집합) 확보 위해 select_top_universe 재호출
+    full_uni = select_top_universe(
+        fold_train_start="20250301", fold_test_end="20260228",
+        n_stocks=30, min_days_present=120,
+    )
+    kosdaq_full = _norm_index("KQ11", RECENT_END)
+
+    print("[kosdaq-regime] recent 로드...")
+    datasets["recent"] = build_recent(full_uni, kosdaq_full)
+
+    # 모든 dataset 의 regime index 를 KOSDAQ 로 교체
+    for name, ds in datasets.items():
+        ds.kospi_daily_df = kosdaq_full  # KOSDAQ 기준으로 통일
+
+    ds_order = ["fold1", "fold2", "fold3", "oos", "recent"]
+    ds_order = [d for d in ds_order if d in datasets]
+
+    # 평가
+    results: Dict[str, Dict[str, Dict]] = {}  # signal -> dataset -> kpi
+    for sig in SIGNALS:
+        results[sig["label"]] = {}
+        for name in ds_order:
+            ds = datasets[name]
+            strat = MACDCrossRegimeFilterStrategy(
+                regime_filter_enabled=sig["enabled"],
+                kospi_daily_df=ds.kospi_daily_df if sig["enabled"] else None,
+                signal_type=sig["signal_type"], signal_threshold=sig["threshold"], **BEST,
+            )
+            results[sig["label"]][name] = evaluate(strat, ds)
+
+    # 출력: return 매트릭스
+    print("\n" + "=" * 90)
+    print("RETURN by signal × dataset (KOSDAQ/KQ11 regime)")
+    print("=" * 90)
+    hdr = f"{'signal':<16}" + "".join(f"{n:>12}" for n in ds_order)
+    print(hdr)
+    for sig in SIGNALS:
+        row = f"{sig['label']:<16}"
+        for name in ds_order:
+            row += f"{results[sig['label']][name]['return']:>+11.2%} "
+        print(row)
+
+    # Δret vs off
+    print("\n" + "=" * 90)
+    print("Δreturn vs off  (양수=개선)   [trades in brackets]")
+    print("=" * 90)
+    print(hdr)
+    off = results["off"]
+    for sig in SIGNALS:
+        if sig["label"] == "off":
+            continue
+        row = f"{sig['label']:<16}"
+        for name in ds_order:
+            d = results[sig["label"]][name]["return"] - off[name]["return"]
+            tr = results[sig["label"]][name]["trades"]
+            row += f"{d:>+8.2%}[{tr:>2}] "
+        print(row)
+
+    # 판정
+    print("\n" + "=" * 90)
+    print("판정 (나쁜장 완화 + 좋은장 미악화)")
+    print("=" * 90)
+    for sig in SIGNALS:
+        if sig["label"] == "off":
+            continue
+        bad_ok, good_ok, notes = True, True, []
+        for name in ds_order:
+            base = off[name]["return"]
+            d = results[sig["label"]][name]["return"] - base
+            if base < 0:  # 나쁜장
+                if d <= 0:
+                    bad_ok = False
+                notes.append(f"{name}(bad Δ{d:+.1%})")
+            else:  # 좋은장
+                if d < -0.005:
+                    good_ok = False
+                notes.append(f"{name}(good Δ{d:+.1%})")
+        verdict = "PASS" if (bad_ok and good_ok) else ("PARTIAL" if (bad_ok or good_ok) else "FAIL")
+        print(f"  {sig['label']:<16} {verdict:<8} bad_ok={bad_ok} good_ok={good_ok}")
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/macd_cross_recent_mv.py
+++ b/analysis/macd_cross_recent_mv.py
@@ -1,0 +1,140 @@
+"""macd_cross 멀티버스 5~6월 확장 검증 (손절 + 레짐).
+
+기존 하니스(backtests/multiverse/macd_cross_*)는 OOS_TEST_END=20260424 까지만
+평가한다. 정작 사용자가 우려하는 5~6월 손실 구간이 빠져 있어, 동일 방법론
+(Stage2 universe, 미래참조 금지, 엔진 마찰)으로 'recent'(20260425~20260604)
+데이터셋을 추가해 SL(10% 포함)·레짐 신호를 재검증한다.
+
+대조용으로 oos(20260301~20260424)도 같이 평가해 이전 summary 수치 재현성 확인.
+"""
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pandas as pd
+
+from backtests.common.engine import BacktestEngine
+from backtests.common.data_loader import (
+    load_minute_df, load_daily_df, load_index_df,
+)
+from backtests.multiverse.universe import select_top_universe
+from backtests.multiverse.macd_cross_mv_common import (
+    Dataset, build_cell_kpis, _trading_days_count,
+)
+from backtests.strategies.macd_cross_exit_overlay import MACDCrossExitOverlayStrategy
+from backtests.strategies.macd_cross_regime_filter import MACDCrossRegimeFilterStrategy
+
+BEST = {"fast_period": 14, "slow_period": 34, "signal_period": 12, "entry_hhmm_min": 1430}
+DAILY_START = "20250101"
+
+WINDOWS = [
+    ("oos",    "20260301", "20260424"),   # 대조 (이전 summary 와 비교)
+    ("recent", "20260425", "20260604"),   # 신규 — 5~6월 손실 구간
+]
+
+SL_GRID = [None, 0.03, 0.05, 0.07, 0.10]   # 10% (광역 재난손절) 추가
+REGIME_CELLS = [
+    {"label": "off",            "enabled": False, "signal_type": "ma20_below_prev", "threshold": None},
+    {"label": "5d_drop_-2pct",  "enabled": True,  "signal_type": "5d_return_drop",  "threshold": -0.02},
+    {"label": "5d_drop_-3pct",  "enabled": True,  "signal_type": "5d_return_drop",  "threshold": -0.03},
+    {"label": "20d_neg_-3pct",  "enabled": True,  "signal_type": "20d_return_neg",  "threshold": -0.03},
+]
+
+
+def build_datasets() -> Dict[str, Dataset]:
+    uni = select_top_universe(
+        fold_train_start="20250301", fold_test_end="20260228",
+        n_stocks=30, min_days_present=120,
+    )
+    full_start = min(w[1] for w in WINDOWS)
+    full_end = max(w[2] for w in WINDOWS)
+    minute_df = load_minute_df(uni, full_start, full_end)
+    daily_df = load_daily_df(uni, DAILY_START, full_end)
+    def _norm_index(code):
+        raw = load_index_df(code, DAILY_START, full_end)
+        return pd.DataFrame({
+            "trade_date": raw["trade_date"].astype(str),
+            "close": raw["close"].astype(float),
+        }).sort_values("trade_date").reset_index(drop=True)
+    kospi_norm = _norm_index("KS11")
+    kosdaq_norm = _norm_index("KQ11")
+
+    minute_full = {c: minute_df[minute_df["stock_code"] == c].reset_index(drop=True) for c in uni}
+    daily_full = {c: daily_df[daily_df["stock_code"] == c].reset_index(drop=True) for c in uni}
+
+    out: Dict[str, Dataset] = {}
+    for name, start, end in WINDOWS:
+        m_by = {
+            c: minute_full[c][
+                (minute_full[c]["trade_date"] >= start) & (minute_full[c]["trade_date"] <= end)
+            ].reset_index(drop=True) for c in uni
+        }
+        d_by = {c: daily_full[c][daily_full[c]["trade_date"] <= end].reset_index(drop=True) for c in uni}
+        nonempty = [c for c in uni if len(m_by[c]) > 0]
+        out[name] = Dataset(
+            name=name, minute_start=start, minute_end=end, daily_start=DAILY_START,
+            minute_by_code={c: m_by[c] for c in nonempty},
+            daily_by_code={c: d_by[c] for c in nonempty},
+            universe=nonempty, kospi_daily_df=kospi_norm,
+        )
+        out[name].kosdaq_daily_df = kosdaq_norm  # 동적 부착 (regime 비교용)
+        print(f"  {name}: {start}~{end}, {len(nonempty)} stocks, {_trading_days_count(m_by)} days")
+    return out
+
+
+def evaluate(strategy, ds: Dataset) -> Dict:
+    eng = BacktestEngine(
+        strategy=strategy, initial_capital=10_000_000,
+        universe=ds.universe, minute_df_by_code=ds.minute_by_code,
+        daily_df_by_code=ds.daily_by_code,
+    )
+    result = eng.run()
+    return build_cell_kpis(
+        equity=result.equity_curve, trades=result.trades,
+        trading_days=_trading_days_count(ds.minute_by_code),
+    )
+
+
+def fmt(k: Dict) -> str:
+    return (f"calmar={k['calmar']:>+8.2f}  ret={k['return']:>+7.2%}  "
+            f"mdd={k['mdd']:>+6.2%}  win={k['win_rate']:>5.1%}  "
+            f"trades={k['trades']:>3}  top1={k['top1_share']:>+6.2f}  "
+            f"maxloss={k['max_consec_loss']:>2}")
+
+
+def main():
+    print("[recent-mv] datasets 로드...")
+    ds = build_datasets()
+
+    for name in ("oos", "recent"):
+        d = ds[name]
+        print(f"\n{'='*100}\n[{name}] {d.minute_start}~{d.minute_end}\n{'='*100}")
+
+        print("\n-- SL sweep (tp=off, reversal=off) --")
+        base = None
+        for sl in SL_GRID:
+            strat = MACDCrossExitOverlayStrategy(sl_pct=sl, tp_pct=None, intraday_reversal=False, **BEST)
+            k = evaluate(strat, d)
+            if sl is None:
+                base = k
+            tag = "off " if sl is None else f"{sl:.0%}"
+            dret = "" if base is None or sl is None else f"  Δret={k['return']-base['return']:>+6.2%}"
+            print(f"  SL={tag}: {fmt(k)}{dret}")
+
+        for idx_label, idx_df in (("KOSPI/KS11", d.kospi_daily_df),
+                                  ("KOSDAQ/KQ11", d.kosdaq_daily_df)):
+            print(f"\n-- regime filter on {idx_label} (signal-based entry block) --")
+            for rc in REGIME_CELLS:
+                strat = MACDCrossRegimeFilterStrategy(
+                    regime_filter_enabled=rc["enabled"],
+                    kospi_daily_df=idx_df if rc["enabled"] else None,
+                    signal_type=rc["signal_type"], signal_threshold=rc["threshold"], **BEST,
+                )
+                k = evaluate(strat, d)
+                print(f"  {rc['label']:<16}: {fmt(k)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/macd_cross_stoploss_counterfactual.py
+++ b/analysis/macd_cross_stoploss_counterfactual.py
@@ -1,0 +1,115 @@
+"""macd_cross 5~6월 실거래 22건 손절 반사실(counterfactual) 시뮬.
+
+각 거래의 매수~실제청산 구간 분봉을 걸어가며, 장중 손절선 X%를 먼저
+건드렸으면 거기서 청산했을 때의 순손익을 실제와 비교한다.
+- 갭하락(시가 < 손절가)이면 시가 체결(보수적)
+- 수수료: 매수/매도 편도 0.014%, 매도세 0.18% (config/trading_config.json)
+"""
+import psycopg2
+from datetime import datetime
+
+COMMISSION = 0.00014
+TAX = 0.0018  # 매도시만
+
+# (buy_id, code, qty, buy_px, buy_ts, sell_px, sell_ts, actual_net)
+TRADES = [
+    (3986, '006800', 12, 79000, '2026-05-07 14:31:17', 79700, '2026-05-11 15:00:09', 6412),
+    (3987, '010170', 44, 22150, '2026-05-08 14:31:16', 28650, '2026-05-12 15:00:07', 283418),
+    (3988, '028050', 15, 62200, '2026-05-08 14:31:17', 54500, '2026-05-12 15:00:10', -117217),
+    (3989, '068270', 5, 199100, '2026-05-08 14:31:17', 194000, '2026-05-12 15:00:13', -27521),
+    (3994, '483650', 4, 249500, '2026-05-13 14:31:17', 256500, '2026-05-15 09:01:06', 25870),
+    (3996, '322000', 5, 199600, '2026-05-15 14:31:23', 208000, '2026-05-19 09:01:10', 39843),
+    (3997, '034220', 73, 13980, '2026-05-15 14:31:24', 13370, '2026-05-19 09:01:10', -46566),
+    (3998, '196170', 2, 370500, '2026-05-15 14:31:24', 374000, '2026-05-19 09:01:10', 5445),
+    (3999, '088350', 191, 5390, '2026-05-15 14:31:25', 5670, '2026-05-19 09:01:13', 51235),
+    (4004, '347700', 24, 43250, '2026-05-19 14:31:18', 42795, '2026-05-21 09:01:07', -13058),
+    (4006, '034220', 68, 15230, '2026-05-22 14:31:15', 15590, '2026-05-26 15:00:08', 22278),
+    (4007, '000270', 6, 165700, '2026-05-22 14:31:20', 166400, '2026-05-26 15:00:08', 2124),
+    (4008, '222800', 7, 132700, '2026-05-22 14:31:20', 133700, '2026-05-26 15:00:08', 5054),
+    (4009, '036540', 93, 11210, '2026-05-26 14:31:16', 9180, '2026-05-28 09:01:08', -190592),
+    (4013, '010170', 37, 27350, '2026-05-27 14:31:28', 24450, '2026-05-29 09:01:06', -109197),
+    (4014, '403870', 18, 55900, '2026-05-27 14:31:29', 50600, '2026-05-29 09:01:09', -97308),
+    (4015, '000990', 4, 203500, '2026-05-27 14:31:30', 194800, '2026-05-29 09:01:09', -36426),
+    (4020, '417010', 74, 12820, '2026-05-29 14:31:18', 10750, '2026-06-02 09:01:09', -154856),
+    (4021, '035420', 3, 279500, '2026-06-01 14:31:18', 266000, '2026-06-04 09:01:20', -42166),
+    (4022, '028260', 2, 465000, '2026-06-01 14:31:23', 505000, '2026-06-04 09:01:24', 77910),
+    (4024, '108490', 2, 410500, '2026-06-02 14:31:16', 339000, '2026-06-04 15:00:12', -144430),
+    (4025, '454910', 5, 163800, '2026-06-02 14:31:17', 157800, '2026-06-04 15:00:15', -31645),
+]
+
+conn = psycopg2.connect(host='127.0.0.1', port=5433, dbname='robotrader', user='postgres', password='')
+cur = conn.cursor()
+
+
+def net_pnl(buy_px, sell_px, qty):
+    buy_val = buy_px * qty
+    sell_val = sell_px * qty
+    fees = buy_val * COMMISSION + sell_val * (COMMISSION + TAX)
+    return (sell_val - buy_val) - fees
+
+
+def candles(code, start, end):
+    cur.execute(
+        """SELECT datetime, open, high, low, close FROM minute_candles
+           WHERE stock_code=%s AND datetime > %s AND datetime <= %s
+           ORDER BY datetime""", (code, start, end))
+    return cur.fetchall()
+
+
+def simulate(stop_pct):
+    total = 0
+    rows = []
+    for (bid, code, qty, bpx, bts, spx, sts, actual) in TRADES:
+        stop_px = bpx * (1 - stop_pct)
+        cs = candles(code, bts, sts)
+        fill = None
+        ftime = None
+        for (dt, o, h, lo, c) in cs:
+            if lo <= stop_px:
+                fill = o if o < stop_px else stop_px  # 갭하락이면 시가 체결
+                ftime = dt
+                break
+        if fill is None:
+            # 손절 미발동 → 실제 청산가 사용
+            cf = net_pnl(bpx, spx, qty)
+            triggered = ''
+        else:
+            cf = net_pnl(bpx, fill, qty)
+            triggered = f'STOP@{int(fill)} {ftime:%m-%d %H:%M}'
+        total += cf
+        rows.append((code, actual, int(cf), triggered))
+    return total, rows
+
+
+actual_total = sum(t[7] for t in TRADES)
+print(f"실제 순손익 합계: {actual_total:,}원  (22건)\n")
+print(f"{'손절선':>6} | {'순손익합계':>12} | {'vs실제':>10} | 발동건수")
+print('-' * 50)
+for pct in [0.03, 0.04, 0.05, 0.06, 0.07, 0.10, 0.12, 0.15]:
+    total, rows = simulate(pct)
+    n_trig = sum(1 for r in rows if r[3])
+    print(f"{pct*100:>5.0f}% | {total:>12,} | {total-actual_total:>+10,} | {n_trig}건")
+
+for lvl in (0.10, 0.15):
+    print(f"\n=== 손절 {lvl:.0%} 상세 (실거래 22건, 갭 체결 메커니즘 확인) ===")
+    total_d, rows_d = simulate(lvl)
+    print(f"  [{lvl:.0%} 합계] 실제 {actual_total:,} -> 손절後 {int(total_d):,}  (차이 {int(total_d)-actual_total:+,})")
+    for (code, actual, cf, trig) in rows_d:
+        diff = cf - actual
+        mark = 'WIN_KILLED' if (actual > 0 and cf < 0) else ('improved' if cf > actual else ('worse' if cf < actual else ''))
+        print(f"  {code}: actual {actual:>+9,} -> stop {cf:>+9,} (Δ{diff:>+8,}) {trig} {mark}")
+
+print("\n=== 손절 3% 상세 (승자 보존 점검) ===")
+total, rows = simulate(0.03)
+for (code, actual, cf, trig) in rows:
+    mark = 'WIN_KILLED' if (actual > 0 and cf < 0) else ('improved' if cf > actual else ('worse' if cf < actual else ''))
+    print(f"  {code}: actual {actual:>+9,} -> stop {cf:>+9,} {trig} {mark}")
+
+print("\n=== 손절 5% 상세 ===")
+total, rows = simulate(0.05)
+for (code, actual, cf, trig) in rows:
+    mark = '←개선' if cf > actual else ('←악화' if cf < actual else '')
+    print(f"  {code}: 실제 {actual:>+9,} → 손절後 {cf:>+9,} {trig} {mark}")
+
+cur.close()
+conn.close()

--- a/config/strategy_settings.py
+++ b/config/strategy_settings.py
@@ -71,6 +71,16 @@ class StrategySettings:
         APPLY_LIVE_OVERLAY = False             # 승격 시 True 검토
         ALLOWED_WEEKDAYS = [0, 1, 2, 3, 4]
 
+        # ---- KOSDAQ 레짐 필터 (2026-06-04 도입) ----
+        # KOSDAQ(KQ11) 직전 N거래일 수익률 <= 임계% 이면 당일 macd_cross 매수 차단.
+        # real 모드 전용 (서킷브레이커와 동일 레이어). 진입일 당일 제외 = lookahead 0.
+        # 검증: analysis/macd_cross_kosdaq_regime_validate.py — 5d_drop_-2pct 가
+        #   fold1/2/3+oos+recent 5개 데이터셋 전부 PASS (나쁜장 완화 + 좋은장 미악화).
+        #   백테스트 신호식: ret5 = close[D-1]/close[D-6]-1 <= threshold (shift1).
+        KOSDAQ_REGIME_FILTER_ENABLED = True
+        KOSDAQ_REGIME_LOOKBACK_DAYS = 5
+        KOSDAQ_REGIME_THRESHOLD_PCT = -2.0     # 퍼센트 (-2.0 = -2%)
+
         # ---- 실거래 / 가상 라우팅 (Phase 1~4 완료, 2026-04-27 실거래 전환) ----
         # True : 시그널 발생 시 execute_virtual_buy 라우팅 (페이퍼)
         # False: KIS 실 계좌 시장가 주문 (실거래) ← 현재

--- a/core/pre_market_analyzer.py
+++ b/core/pre_market_analyzer.py
@@ -751,6 +751,63 @@ class PreMarketAnalyzer:
             logger.error(f"[서킷브레이커] DB 조회 오류: {e}")
             return None
 
+    def _get_kosdaq_trailing_return(
+        self, lookback_days: int = 5, as_of_yyyymmdd: Optional[str] = None,
+    ) -> Optional[float]:
+        """KOSDAQ(KQ11) 직전 lookback_days 거래일 수익률 (%) 조회.
+
+        백테스트 5d_return_drop 신호식 복제: ret = close[D-1]/close[D-(1+lookback)] - 1.
+        as_of_yyyymmdd (진입일 D) 가 주어지면 그 날짜를 **제외**한 직전 종가만 사용
+        (lookahead 0). daily_candles 에 D 일봉이 이미 있어도 안전.
+
+        Args:
+            lookback_days: 수익률 기간 (거래일). 5 면 종가 6개 필요.
+            as_of_yyyymmdd: 진입일 'YYYYMMDD'. None 이면 가장 최근 종가 기준.
+
+        Returns:
+            수익률 퍼센트 (예: -2.5). 데이터 부족/오류 시 None.
+        """
+        try:
+            import psycopg2
+            from config.settings import PG_HOST, PG_PORT, PG_DATABASE, PG_USER, PG_PASSWORD
+
+            conn = psycopg2.connect(
+                host=PG_HOST, port=PG_PORT, database=PG_DATABASE,
+                user=PG_USER, password=PG_PASSWORD,
+            )
+            cur = conn.cursor()
+            need = lookback_days + 1
+            if as_of_yyyymmdd:
+                cur.execute('''
+                    SELECT CAST(stck_clpr AS FLOAT)
+                    FROM daily_candles
+                    WHERE stock_code = 'KQ11' AND stck_bsop_date < %s
+                    ORDER BY stck_bsop_date DESC
+                    LIMIT %s
+                ''', (as_of_yyyymmdd, need))
+            else:
+                cur.execute('''
+                    SELECT CAST(stck_clpr AS FLOAT)
+                    FROM daily_candles
+                    WHERE stock_code = 'KQ11'
+                    ORDER BY stck_bsop_date DESC
+                    LIMIT %s
+                ''', (need,))
+            rows = cur.fetchall()
+            conn.close()
+
+            if len(rows) < need:
+                return None
+            recent_close = rows[0][0]              # D-1
+            base_close = rows[lookback_days][0]    # D-(1+lookback)
+            if not base_close or base_close <= 0:
+                return None
+            return (recent_close / base_close - 1) * 100
+
+        except Exception as e:
+            logger.error(f"[레짐필터] KOSDAQ 수익률 DB 조회 오류: {e}")
+            return None
+
     def _test_nxt_api_availability(self) -> bool:
         """NXT API 가용성 테스트 (삼성전자로 시도)"""
         try:

--- a/main.py
+++ b/main.py
@@ -39,6 +39,22 @@ def get_decision_engine():
     return _global_decision_engine
 
 
+# 킬스위치가 집계하는 macd_cross 매도 조회 SQL.
+# ⚠️ 매도 레코드의 strategy 라벨은 emergency_sync 복구 경로에서 '보유종목 자동복구'
+#    로 덮일 수 있다(D+2 보유 중 봇 재시작 시). 매도 라벨만 필터하면 macd_cross
+#    거래를 0건으로 오판하여 킬스위치가 영구 무력화된다(2026-06-04 진단). 매수
+#    레코드(buy_record_id)의 strategy 는 항상 정확하므로 매수 기준으로도 식별한다.
+_MACD_CROSS_KILL_SWITCH_SELL_SQL = """
+    SELECT s.timestamp, s.net_profit
+    FROM real_trading_records s
+    LEFT JOIN real_trading_records b ON s.buy_record_id = b.id
+    WHERE s.action='SELL'
+      AND s.net_profit IS NOT NULL
+      AND (s.strategy = 'macd_cross' OR b.strategy = 'macd_cross')
+    ORDER BY s.timestamp ASC
+"""
+
+
 class DayTradingBot:
     """주식 단타 거래 봇"""
     
@@ -783,7 +799,8 @@ class DayTradingBot:
     def _check_macd_cross_kill_switch_thresholds(self) -> None:
         """누적 -5% 또는 5연속 손실 시 킬 스위치 발동.
 
-        실거래 모드만 평가. real_trading_records.strategy='macd_cross' AND action='SELL'.
+        실거래 모드만 평가. macd_cross 매도는 매수 레코드(buy_record_id)의
+        strategy 로 식별한다 (매도 라벨은 복구 경로에서 덮일 수 있음).
         """
         try:
             if self._macd_cross_mode() != 'real':
@@ -793,13 +810,7 @@ class DayTradingBot:
             # SELL 레코드 시간순 조회
             with self.db_manager._pool_obj.connection() as conn:
                 cur = conn.cursor()
-                cur.execute("""
-                    SELECT timestamp, net_profit
-                    FROM real_trading_records
-                    WHERE strategy='macd_cross' AND action='SELL'
-                      AND net_profit IS NOT NULL
-                    ORDER BY timestamp ASC
-                """)
+                cur.execute(_MACD_CROSS_KILL_SWITCH_SELL_SQL)
                 rows = cur.fetchall()
             if not rows:
                 return
@@ -872,6 +883,45 @@ class DayTradingBot:
             self.logger.warning(f"[macd_cross.cb] 체크 실패 → 차단 안 함: {e}")
             return False
 
+    def _macd_cross_kosdaq_regime_blocks(self, current_time) -> bool:
+        """KOSDAQ 직전 N거래일 수익률 <= 임계% 시 macd_cross 매수 차단 (실거래 전용).
+
+        2026-06-04 도입. analysis/macd_cross_kosdaq_regime_validate.py 검증:
+        5d_drop_-2pct 가 fold1/2/3+oos+recent 5개 전부 PASS (나쁜장 완화 + 좋은장 미악화).
+        백테스트 신호식 ret5=close[D-1]/close[D-6]-1<=thr 를 라이브에 복제 (진입일 제외 = lookahead 0).
+
+        결과 캐시 (당일 1회). 데이터 없으면 보수적으로 False (차단 안 함).
+        """
+        try:
+            from config.strategy_settings import StrategySettings
+            cfg = StrategySettings.MacdCross
+            if not getattr(cfg, 'KOSDAQ_REGIME_FILTER_ENABLED', False):
+                return False
+            today = current_time.date()
+            cache = getattr(self, '_macd_cross_regime_cache', None)
+            if cache and cache.get('date') == today:
+                return cache['blocked']
+
+            as_of = current_time.strftime('%Y%m%d')
+            ret = self.pre_market_analyzer._get_kosdaq_trailing_return(
+                lookback_days=cfg.KOSDAQ_REGIME_LOOKBACK_DAYS, as_of_yyyymmdd=as_of,
+            )
+            if ret is None:
+                self._macd_cross_regime_cache = {'date': today, 'blocked': False}
+                return False
+            blocked = ret <= cfg.KOSDAQ_REGIME_THRESHOLD_PCT
+            self._macd_cross_regime_cache = {'date': today, 'blocked': blocked}
+            if blocked:
+                self.logger.warning(
+                    f"🚫 [macd_cross.regime] KOSDAQ 직전 "
+                    f"{cfg.KOSDAQ_REGIME_LOOKBACK_DAYS}거래일 {ret:+.2f}% "
+                    f"(임계 {cfg.KOSDAQ_REGIME_THRESHOLD_PCT}%) → 매수 차단"
+                )
+            return blocked
+        except Exception as e:
+            self.logger.warning(f"[macd_cross.regime] 체크 실패 → 차단 안 함: {e}")
+            return False
+
     def _macd_cross_mode(self) -> str:
         """macd_cross 운영 모드 결정.
 
@@ -940,6 +990,10 @@ class DayTradingBot:
         # 🚨 실거래 모드 한정: 전일 -3% 서킷브레이커 inherit (자본 보호 absolute)
         # paper 모드는 G1 (백테스트 100% 재현) 원칙으로 미적용.
         if not is_virtual and self._macd_cross_circuit_breaker_blocks(current_time):
+            return
+
+        # 🚨 실거래 모드 한정: KOSDAQ 5거래일 낙폭 레짐필터 (2026-06-04, fold 검증 PASS)
+        if not is_virtual and self._macd_cross_kosdaq_regime_blocks(current_time):
             return
 
         universe_codes = list(strategy._cache.keys()) if hasattr(strategy, '_cache') else []

--- a/tests/integration/test_macd_cross_kill_switch_label.py
+++ b/tests/integration/test_macd_cross_kill_switch_label.py
@@ -1,0 +1,113 @@
+"""킬스위치가 라벨이 덮인 macd_cross 매도를 집계하는지 검증 (회귀 테스트).
+
+배경 (2026-06-04 진단):
+  macd_cross 는 D+2 보유 중 봇 재시작 시 emergency_sync 가 포지션을 재등록하면서
+  매도 레코드의 strategy 가 '보유종목 자동복구' 로 덮인다. 기존 킬스위치 SQL 은
+  `WHERE strategy='macd_cross' AND action='SELL'` 로 매도 라벨만 필터하여
+  실제 macd_cross 손실 23건을 0건으로 오판 → 안전망이 라이브 내내 무력화됐다.
+
+수정: 매수 레코드(buy_record_id)의 strategy 로도 macd_cross 를 식별.
+
+이 테스트는 실데이터를 건드리지 않도록 TEMP TABLE 이 public.real_trading_records 를
+세션 내에서 shadow 하는 방식으로 main.py 의 실제 SQL 상수를 검증한다.
+"""
+import pytest
+
+from main import _MACD_CROSS_KILL_SWITCH_SELL_SQL
+
+try:
+    import psycopg2
+    from config import settings as _settings
+    _conn = psycopg2.connect(
+        host=_settings.PG_HOST, port=_settings.PG_PORT,
+        dbname=_settings.PG_DATABASE, user=_settings.PG_USER,
+        password=_settings.PG_PASSWORD, connect_timeout=3,
+    )
+    _conn.close()
+    _DB_OK = True
+except Exception:
+    _DB_OK = False
+
+pytestmark = pytest.mark.skipif(not _DB_OK, reason="PostgreSQL(robotrader) 미가용 — DB 통합 테스트 skip")
+
+# 기존(버그) SQL: 매도 라벨만 필터 → 덮인 라벨을 놓침
+_OLD_BUGGY_SQL = """
+    SELECT timestamp, net_profit
+    FROM real_trading_records
+    WHERE strategy='macd_cross' AND action='SELL'
+      AND net_profit IS NOT NULL
+    ORDER BY timestamp ASC
+"""
+
+
+@pytest.fixture
+def seeded_conn():
+    """TEMP TABLE 로 public.real_trading_records 를 shadow 하고 대표 행을 적재."""
+    conn = psycopg2.connect(
+        host=_settings.PG_HOST, port=_settings.PG_PORT,
+        dbname=_settings.PG_DATABASE, user=_settings.PG_USER,
+        password=_settings.PG_PASSWORD,
+    )
+    cur = conn.cursor()
+    # 세션 내에서만 존재하며 public 테이블을 가린다. 실데이터 미접촉.
+    cur.execute("CREATE TEMP TABLE real_trading_records (LIKE public.real_trading_records)")
+    # macd_cross 매수 (라벨 정확)
+    cur.execute(
+        """INSERT INTO real_trading_records
+           (id, stock_code, stock_name, action, quantity, price, timestamp, strategy)
+           VALUES (1,'028260','MC_028260','BUY',2,465000,'2026-06-01 14:31:23+09','macd_cross')"""
+    )
+    # 매도: 복구 경로로 라벨이 덮임 + 매수와 buy_record_id 로 연결, 손실
+    cur.execute(
+        """INSERT INTO real_trading_records
+           (id, stock_code, stock_name, action, quantity, price, timestamp, strategy,
+            buy_record_id, net_profit)
+           VALUES (2,'028260','삼성물산','SELL',2,440000,'2026-06-04 09:01:24+09',
+                   %s, 1, -100000)""",
+        ("보유종목 자동복구 (2주 @465,000)",),
+    )
+    yield conn
+    conn.close()  # TEMP TABLE 자동 소멸
+
+
+def test_old_query_misses_relabeled_sell(seeded_conn):
+    """회귀 문서화: 기존 SQL 은 라벨이 덮인 macd_cross 매도를 0건으로 놓친다."""
+    cur = seeded_conn.cursor()
+    cur.execute(_OLD_BUGGY_SQL)
+    rows = cur.fetchall()
+    assert rows == [], "기존 SQL 은 라벨 덮인 매도를 놓쳐야 한다(버그 재현)"
+
+
+def test_fixed_query_counts_relabeled_sell(seeded_conn):
+    """수정 SQL 은 매수 레코드로 식별해 라벨이 덮인 macd_cross 매도를 집계한다."""
+    cur = seeded_conn.cursor()
+    cur.execute(_MACD_CROSS_KILL_SWITCH_SELL_SQL)
+    rows = cur.fetchall()
+    assert len(rows) == 1, f"라벨이 덮여도 매수 기준으로 1건 집계되어야 함 (got {len(rows)})"
+    assert float(rows[0][1]) == -100000.0
+
+
+def test_fixed_query_counts_correctly_labeled_sell(seeded_conn):
+    """매도 라벨이 정상 'macd_cross' 인 경우(buy_record_id 없어도)도 집계."""
+    cur = seeded_conn.cursor()
+    cur.execute(
+        """INSERT INTO real_trading_records
+           (id, stock_code, stock_name, action, quantity, price, timestamp, strategy, net_profit)
+           VALUES (3,'005930','삼성전자','SELL',1,70000,'2026-06-04 15:00:00+09','macd_cross',5000)"""
+    )
+    cur.execute(_MACD_CROSS_KILL_SWITCH_SELL_SQL)
+    rows = cur.fetchall()
+    assert len(rows) == 2, f"덮인 매도 + 정상라벨 매도 = 2건 (got {len(rows)})"
+
+
+def test_fixed_query_excludes_non_macd(seeded_conn):
+    """다른 전략 매도는 집계에서 제외."""
+    cur = seeded_conn.cursor()
+    cur.execute(
+        """INSERT INTO real_trading_records
+           (id, stock_code, stock_name, action, quantity, price, timestamp, strategy, net_profit)
+           VALUES (4,'000660','SK하이닉스','SELL',1,150000,'2026-06-04 15:00:00+09','price_position',-3000)"""
+    )
+    cur.execute(_MACD_CROSS_KILL_SWITCH_SELL_SQL)
+    rows = cur.fetchall()
+    assert len(rows) == 1, f"non-macd 매도는 제외되어야 함 (got {len(rows)})"

--- a/tests/integration/test_macd_cross_regime_filter_live.py
+++ b/tests/integration/test_macd_cross_regime_filter_live.py
@@ -1,0 +1,118 @@
+"""macd_cross KOSDAQ 레짐필터 라이브 배선 검증 (2026-06-04).
+
+1. _macd_cross_kosdaq_regime_blocks 임계 분기 (mock 기반)
+2. _get_kosdaq_trailing_return 신호식이 백테스트 정의와 일치 (실 DB 기반)
+   — 백테스트: ret5 = close[D-1]/close[D-6] - 1 (shift1, lookahead 0)
+"""
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from config.strategy_settings import StrategySettings
+
+
+class _FakeBot:
+    def __init__(self):
+        self.logger = MagicMock()
+        self.pre_market_analyzer = MagicMock()
+
+
+def _bind(bot, *names):
+    from main import DayTradingBot
+    for n in names:
+        setattr(bot, n, DayTradingBot.__dict__[n].__get__(bot, _FakeBot))
+
+
+def _make_bot(trailing_ret):
+    bot = _FakeBot()
+    _bind(bot, '_macd_cross_kosdaq_regime_blocks')
+    bot.pre_market_analyzer._get_kosdaq_trailing_return.return_value = trailing_ret
+    return bot
+
+
+NOW = datetime(2026, 6, 4, 14, 31)
+
+
+def test_regime_blocks_when_below_threshold():
+    """KOSDAQ 5일 -2.5% (<= -2.0%) → 차단."""
+    bot = _make_bot(-2.5)
+    assert bot._macd_cross_kosdaq_regime_blocks(NOW) is True
+
+
+def test_regime_at_exact_threshold_blocks():
+    """정확히 -2.0% → 차단 (<= 경계 포함, 백테스트 cond 와 동일)."""
+    bot = _make_bot(-2.0)
+    assert bot._macd_cross_kosdaq_regime_blocks(NOW) is True
+
+
+def test_regime_no_block_above_threshold():
+    """KOSDAQ 5일 -1.5% (> -2.0%) → 차단 안 함."""
+    bot = _make_bot(-1.5)
+    assert bot._macd_cross_kosdaq_regime_blocks(NOW) is False
+
+
+def test_regime_no_block_when_data_missing():
+    """데이터 없음(None) → 보수적으로 차단 안 함."""
+    bot = _make_bot(None)
+    assert bot._macd_cross_kosdaq_regime_blocks(NOW) is False
+
+
+def test_regime_disabled_flag(monkeypatch):
+    """KOSDAQ_REGIME_FILTER_ENABLED=False → 항상 차단 안 함 (DB 조회도 안 함)."""
+    monkeypatch.setattr(StrategySettings.MacdCross, 'KOSDAQ_REGIME_FILTER_ENABLED', False)
+    bot = _make_bot(-9.0)  # 임계 한참 아래여도
+    assert bot._macd_cross_kosdaq_regime_blocks(NOW) is False
+    bot.pre_market_analyzer._get_kosdaq_trailing_return.assert_not_called()
+
+
+def test_regime_caches_within_day():
+    """같은 날 두 번째 호출은 캐시 사용 (DB 1회만)."""
+    bot = _make_bot(-3.0)
+    assert bot._macd_cross_kosdaq_regime_blocks(NOW) is True
+    assert bot._macd_cross_kosdaq_regime_blocks(datetime(2026, 6, 4, 14, 45)) is True
+    assert bot.pre_market_analyzer._get_kosdaq_trailing_return.call_count == 1
+
+
+# ---------- 실 DB 신호식 일치 검증 ----------
+try:
+    import psycopg2
+    from config import settings as _s
+    _c = psycopg2.connect(host=_s.PG_HOST, port=_s.PG_PORT, dbname=_s.PG_DATABASE,
+                          user=_s.PG_USER, password=_s.PG_PASSWORD, connect_timeout=3)
+    _c.close()
+    _DB_OK = True
+except Exception:
+    _DB_OK = False
+
+
+@pytest.mark.skipif(not _DB_OK, reason="PostgreSQL 미가용")
+def test_trailing_return_matches_backtest_formula():
+    """_get_kosdaq_trailing_return 가 close[D-1]/close[D-6]-1 (lookahead 0) 와 일치."""
+    from core.pre_market_analyzer import PreMarketAnalyzer
+
+    class _FA: pass
+    fa = _FA()
+    fa._get_kosdaq_trailing_return = (
+        PreMarketAnalyzer.__dict__['_get_kosdaq_trailing_return'].__get__(fa, _FA)
+    )
+
+    as_of = "20260604"
+    got = fa._get_kosdaq_trailing_return(lookback_days=5, as_of_yyyymmdd=as_of)
+
+    # 독립 계산: as_of 제외 직전 6개 종가
+    import psycopg2
+    conn = psycopg2.connect(host=_s.PG_HOST, port=_s.PG_PORT, dbname=_s.PG_DATABASE,
+                            user=_s.PG_USER, password=_s.PG_PASSWORD)
+    cur = conn.cursor()
+    cur.execute('''SELECT CAST(stck_clpr AS FLOAT) FROM daily_candles
+                   WHERE stock_code='KQ11' AND stck_bsop_date < %s
+                   ORDER BY stck_bsop_date DESC LIMIT 6''', (as_of,))
+    rows = cur.fetchall()
+    conn.close()
+
+    if len(rows) < 6:
+        pytest.skip("KQ11 일봉 6개 미만")
+    expected = (rows[0][0] / rows[5][0] - 1) * 100
+    assert got is not None
+    assert abs(got - expected) < 1e-6, f"got {got}, expected {expected}"


### PR DESCRIPTION
## 배경

5~6월 macd_cross 실거래에서 **-51만원 손실** 발생. 진단 결과 두 가지 문제와 조치를 도출.

## 1. 킬스위치 라벨 버그 (안전망 무력화) — 🔴 치명

- 킬스위치 SQL이 `WHERE strategy='macd_cross' AND action='SELL'`로 **매도 라벨**만 필터
- 그러나 macd_cross는 D+2 보유 중 봇 재시작 시 `emergency_sync`가 포지션을 재등록하며 매도 strategy가 `'보유종목 자동복구'`로 덮임 → 쿼리 **0건 반환** → `-5%/5연패` 안전망이 **라이브 내내 평가조차 안 됨**
- 검증: 05-01 이후 매도 23건 중 `strategy='macd_cross'` = 0건
- **수정**: `buy_record_id` LEFT JOIN으로 **불변인 매수 레코드 strategy** 기준 식별 (`s.strategy='macd_cross' OR b.strategy='macd_cross'`)

## 2. KOSDAQ 5일낙폭 레짐필터 (손실 근본 대응)

- 손절(tight 3~7% / -10% / -15%)은 **오버나이트 갭다운에 무력** — 멀티버스·실거래 counterfactual 모두 비강건(outlier 의존, 승자 휩쏘). 기각.
- 기존 KOSPI 레짐필터는 **엉뚱한 지수** — 5~6월 손실은 코스닥 성장주인데 그 시기 코스피는 강세
- **KOSDAQ(KQ11) 직전 5거래일 -2% 이하 시 진입 차단** 도입
- 검증(`analysis/macd_cross_kosdaq_regime_validate.py`): fold1/2/3+oos+recent **5개 데이터셋 전부 PASS** (나쁜장 완화 + 좋은장 미악화, -2%·-3% plateau)
- real 모드 전용, 진입일 제외 = lookahead 0 (백테스트 신호식 `close[D-1]/close[D-6]-1` 복제)

## 검증

- 킬스위치 회귀 테스트 **4건** (구 SQL 0건 ↔ 신 SQL 집계 대조, TEMP TABLE로 실데이터 미접촉)
- 레짐필터 테스트 **7건** (임계 분기 + 실 DB 신호식 = 백테스트 공식 일치)
- macd_cross 전체 스위트 **60 passed, 1 skipped**
- 현재 KOSDAQ 5일 = **-12.56%** → 필터가 즉시 차단 (최근 손실 국면 정확히 포착)

## 적용 시점

봇 재시작부터 적용. 재시작 시 ① 킬스위치가 누적 -5% 평가 → macd_cross 자동 정지 가능 ② KOSDAQ 레짐필터 진입 차단.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
